### PR TITLE
Add Builder Pattern to Connection Parameters

### DIFF
--- a/spatialos-sdk/examples/project-example/main.rs
+++ b/spatialos-sdk/examples/project-example/main.rs
@@ -12,20 +12,18 @@ use spatialos_sdk::worker::core::{EntityId, InterestOverride, LogLevel};
 use spatialos_sdk::worker::core::metrics::*;
 use uuid::Uuid;
 
+static HOST: &str = "127.0.0.1";
+static PORT: u16 = 7777;
+
 fn main() {
     println!("Entered program");
 
     let connection_params = parameters::ConnectionParameters::new("RustWorker")
-        .using_tcp(None)
-        .using_external_ip();
-
-    let mut connection_parameters =
-        parameters::ReceptionistConnectionParameters::new("127.0.0.1", 7777)
-        .with_params(connection_params);
+        .using_tcp();
     
     let worker_id = get_worker_id();
 
-    let mut worker_connection = match get_connection_block(&connection_parameters, &worker_id) {
+    let mut worker_connection = match get_connection_block(&connection_params, &worker_id) {
         Ok(c) => c,
         Err(e) => panic!("Failed to connect with block: \n{}", e),
     };
@@ -100,21 +98,21 @@ fn check_for_flag(connection: &WorkerConnection, flag_name: &str) {
 }
 
 fn get_connection_block(
-    params: &parameters::ReceptionistConnectionParameters,
+    params: &parameters::ConnectionParameters,
     worker_id: &str,
 ) -> Result<WorkerConnection, String> {
-    let mut future = WorkerConnection::connect_receptionist_async(worker_id, params);
+    let mut future = WorkerConnection::connect_receptionist_async(worker_id, HOST, PORT, params);
     future.get()
 }
 
 fn get_connection_poll(
-    params: &parameters::ReceptionistConnectionParameters,
-    worker_id: &str,
+    params: &parameters::ConnectionParameters,
+    worker_id: &str
 ) -> Result<WorkerConnection, String> {
     const NUM_ATTEMPTS: u8 = 3;
     const TIME_BETWEEN_ATTEMPTS_MILLIS: u64 = 1000;
 
-    let mut future = WorkerConnection::connect_receptionist_async(worker_id, params);
+    let mut future = WorkerConnection::connect_receptionist_async(worker_id, HOST, PORT, params);
 
     let mut res: Option<WorkerConnection> = None;
     let mut err: Option<String> = None;

--- a/spatialos-sdk/examples/project-example/main.rs
+++ b/spatialos-sdk/examples/project-example/main.rs
@@ -14,13 +14,15 @@ use uuid::Uuid;
 
 fn main() {
     println!("Entered program");
-    let mut connection_parameters = parameters::ReceptionistConnectionParameters {
-        hostname: "127.0.0.1".to_owned(),
-        port: 7777,
-        connection_params: parameters::ConnectionParameters::default(),
-    };
-    connection_parameters.connection_params.worker_type = "RustWorker".to_owned();
 
+    let connection_params = parameters::ConnectionParameters::new("RustWorker")
+        .using_tcp(None)
+        .using_external_ip();
+
+    let mut connection_parameters =
+        parameters::ReceptionistConnectionParameters::new("127.0.0.1", 7777)
+        .with_params(connection_params);
+    
     let worker_id = get_worker_id();
 
     let mut worker_connection = match get_connection_block(&connection_parameters, &worker_id) {

--- a/spatialos-sdk/examples/project-example/main.rs
+++ b/spatialos-sdk/examples/project-example/main.rs
@@ -18,9 +18,8 @@ static PORT: u16 = 7777;
 fn main() {
     println!("Entered program");
 
-    let connection_params = parameters::ConnectionParameters::new("RustWorker")
-        .using_tcp();
-    
+    let connection_params = parameters::ConnectionParameters::new("RustWorker").using_tcp();
+
     let worker_id = get_worker_id();
 
     let mut worker_connection = match get_connection_block(&connection_params, &worker_id) {
@@ -107,7 +106,7 @@ fn get_connection_block(
 
 fn get_connection_poll(
     params: &parameters::ConnectionParameters,
-    worker_id: &str
+    worker_id: &str,
 ) -> Result<WorkerConnection, String> {
     const NUM_ATTEMPTS: u8 = 3;
     const TIME_BETWEEN_ATTEMPTS_MILLIS: u64 = 1000;

--- a/spatialos-sdk/src/worker/core/connection.rs
+++ b/spatialos-sdk/src/worker/core/connection.rs
@@ -1,11 +1,11 @@
 use std::ffi::{CStr, CString};
 use std::ptr;
-use worker::core::{EntityId, InterestOverride, LogLevel, RequestId};
 use worker::core::commands::*;
 use worker::core::component::ComponentUpdate;
 use worker::core::metrics::Metrics;
 use worker::core::op::{DisconnectOp, OpList, WorkerOp};
 use worker::core::parameters::{CommandParameters, ConnectionParameters};
+use worker::core::{EntityId, InterestOverride, LogLevel, RequestId};
 use worker::internal::bindings::*;
 
 /// Connection trait to allow for mocking the connection.
@@ -106,8 +106,7 @@ impl WorkerConnection {
         port: u16,
         params: &ConnectionParameters,
     ) -> WorkerConnectionFuture {
-        let hostname_cstr =
-            CString::new(hostname).expect("Received 0 byte in supplied hostname.");
+        let hostname_cstr = CString::new(hostname).expect("Received 0 byte in supplied hostname.");
         let worker_id_cstr =
             CString::new(worker_id).expect("Received 0 byte in supplied Worker ID");
         let conn_params = params.to_worker_sdk();

--- a/spatialos-sdk/src/worker/core/connection.rs
+++ b/spatialos-sdk/src/worker/core/connection.rs
@@ -1,12 +1,11 @@
 use std::ffi::{CStr, CString};
 use std::ptr;
-
+use worker::core::{EntityId, InterestOverride, LogLevel, RequestId};
 use worker::core::commands::*;
 use worker::core::component::ComponentUpdate;
 use worker::core::metrics::Metrics;
 use worker::core::op::{DisconnectOp, OpList, WorkerOp};
-use worker::core::parameters::{CommandParameters, ReceptionistConnectionParameters};
-use worker::core::{EntityId, InterestOverride, LogLevel, RequestId};
+use worker::core::parameters::{CommandParameters, ConnectionParameters};
 use worker::internal::bindings::*;
 
 /// Connection trait to allow for mocking the connection.
@@ -103,17 +102,19 @@ impl WorkerConnection {
 
     pub fn connect_receptionist_async(
         worker_id: &str,
-        params: &ReceptionistConnectionParameters,
+        hostname: &str,
+        port: u16,
+        params: &ConnectionParameters,
     ) -> WorkerConnectionFuture {
         let hostname_cstr =
-            CString::new(params.hostname.clone()).expect("Received 0 byte in supplied hostname.");
+            CString::new(hostname).expect("Received 0 byte in supplied hostname.");
         let worker_id_cstr =
             CString::new(worker_id).expect("Received 0 byte in supplied Worker ID");
-        let conn_params = params.connection_params.to_worker_sdk();
+        let conn_params = params.to_worker_sdk();
         let future_ptr = unsafe {
             Worker_ConnectAsync(
                 hostname_cstr.as_ptr(),
-                params.port,
+                port,
                 worker_id_cstr.as_ptr(),
                 &conn_params.native_struct,
             )

--- a/spatialos-sdk/src/worker/core/parameters.rs
+++ b/spatialos-sdk/src/worker/core/parameters.rs
@@ -29,6 +29,21 @@ pub struct ReceptionistConnectionParameters {
     pub connection_params: ConnectionParameters,
 }
 
+impl ReceptionistConnectionParameters {
+    pub fn new(hostname: &str, port: u16) -> Self {
+        ReceptionistConnectionParameters {
+            hostname: hostname.to_owned(),
+            port,
+            connection_params: ConnectionParameters::default()
+        }
+    }
+
+    pub fn with_params(mut self, params: ConnectionParameters) -> Self{
+        self.connection_params = params;
+        self
+    }
+}
+
 pub struct LocatorConnectionParameters {}
 
 pub struct ConnectionParameters {
@@ -44,6 +59,46 @@ pub struct ConnectionParameters {
 }
 
 impl ConnectionParameters {
+    pub fn new(worker_type: &str) -> Self {
+        let mut params = ConnectionParameters::default();
+        params.worker_type = worker_type.to_owned();
+        params
+    }
+
+    pub fn with_protocol_logging(mut self, log_prefix: &str) -> Self {
+        self.enable_protocol_logging_at_startup = true;
+        self.protocol_logging.log_prefix = log_prefix.to_owned();
+        self
+    }
+
+    pub fn using_tcp(mut self, params: Option<TcpNetworkParameters>) -> Self {
+        self.network.connection_type = ConnectionType::TCP;
+        self.network.tcp = match params {
+            Some(p) => p,
+            None => TcpNetworkParameters::default()
+        };
+        self
+    }
+
+    pub fn using_raknet(mut self, params: Option<RakNetNetworkParameters>) -> Self {
+        self.network.connection_type = ConnectionType::RakNet;
+        self.network.raknet = match params {
+            Some(p) => p,
+            None => RakNetNetworkParameters::default()
+        };
+        self
+    }
+
+    pub fn using_external_ip(mut self) -> Self {
+        self.network.use_external_ip = true;
+        self
+    }
+
+    pub fn with_connection_timeout(mut self, timeout_millis: u64) -> Self {
+        self.network.connection_timeout_millis = timeout_millis;
+        self
+    }
+
     pub fn default() -> Self {
         ConnectionParameters {
             worker_type: "".to_owned(),

--- a/spatialos-sdk/src/worker/core/parameters.rs
+++ b/spatialos-sdk/src/worker/core/parameters.rs
@@ -106,17 +106,31 @@ pub enum ProtocolType {
 }
 
 impl ProtocolType {
-    fn to_worker_sdk(&self) -> (u8, Worker_RakNetNetworkParameters, Worker_TcpNetworkParameters) {
+    fn to_worker_sdk(
+        &self,
+    ) -> (
+        u8,
+        Worker_RakNetNetworkParameters,
+        Worker_TcpNetworkParameters,
+    ) {
         match self {
             ProtocolType::Tcp(params) => {
                 let tcp_params = params.to_worker_sdk();
                 let raknet_params = RakNetNetworkParameters::default().to_worker_sdk();
-                (Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_TCP as u8, raknet_params, tcp_params)
+                (
+                    Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_TCP as u8,
+                    raknet_params,
+                    tcp_params,
+                )
             }
             ProtocolType::RakNet(params) => {
                 let tcp_params = TcpNetworkParameters::default().to_worker_sdk();
                 let raknet_params = params.to_worker_sdk();
-                (Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_RAKNET as u8, raknet_params, tcp_params)
+                (
+                    Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_RAKNET as u8,
+                    raknet_params,
+                    tcp_params,
+                )
             }
         }
     }

--- a/spatialos-sdk/src/worker/core/parameters.rs
+++ b/spatialos-sdk/src/worker/core/parameters.rs
@@ -106,15 +106,17 @@ pub enum ProtocolType {
 }
 
 impl ProtocolType {
-    fn to_worker_sdk(&self) -> (u8, Option<Worker_RakNetNetworkParameters>, Option<Worker_TcpNetworkParameters>) {
+    fn to_worker_sdk(&self) -> (u8, Worker_RakNetNetworkParameters, Worker_TcpNetworkParameters) {
         match self {
             ProtocolType::Tcp(params) => {
-                let worker_params = params.to_worker_sdk();
-                (Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_TCP as u8, None, Some(worker_params))
+                let tcp_params = params.to_worker_sdk();
+                let raknet_params = RakNetNetworkParameters::default().to_worker_sdk();
+                (Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_TCP as u8, raknet_params, tcp_params)
             }
             ProtocolType::RakNet(params) => {
-                let worker_params = params.to_worker_sdk();
-                (Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_RAKNET as u8, Some(worker_params), None)
+                let tcp_params = TcpNetworkParameters::default().to_worker_sdk();
+                let raknet_params = params.to_worker_sdk();
+                (Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_RAKNET as u8, raknet_params, tcp_params)
             }
         }
     }
@@ -142,14 +144,8 @@ impl NetworkParameters {
         Worker_NetworkParameters {
             use_external_ip: self.use_external_ip as u8,
             connection_type: protocol_type,
-            raknet: match raknet_params {
-                Some(p) => p,
-                None => RakNetNetworkParameters::default().to_worker_sdk(),
-            },
-            tcp: match tcp_params {
-                Some(p) => p,
-                None => TcpNetworkParameters::default().to_worker_sdk()
-            },
+            raknet: raknet_params,
+            tcp: tcp_params,
             connection_timeout_millis: self.connection_timeout_millis,
             default_command_timeout_millis: self.default_command_timeout_millis,
         }


### PR DESCRIPTION
This allows for a more idiomatic, clean way of declaring connection parameters.