### PR TITLE
Use futures crate for wrapping futures in WorkerSDK

### DIFF
--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -5,7 +5,12 @@ authors = ["Jamie Brynes <jamiebrynes7@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-spatialos-sdk-sys = { path = "../spatialos-sdk-sys"} 
+spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
+futures = "0.1.25"
+
+[[example]]
+name = "project-example"
+path = "./examples/project-example/main.rs"
 
 [dev-dependencies]
 uuid = { version = "0.7", features = ["v4"] }

--- a/spatialos-sdk/examples/project-example/Cargo.toml
+++ b/spatialos-sdk/examples/project-example/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "spatialos-sdk-project-example"
-version = "0.0.0"
-authors = ["Jamie Brynes <jamiebrynes7@gmail.com>"]
-publish = false
-
-[dependencies]
-spatialos-sdk = { path = "../../"} 

--- a/spatialos-sdk/examples/project-example/lib/connection_handler.rs
+++ b/spatialos-sdk/examples/project-example/lib/connection_handler.rs
@@ -57,8 +57,8 @@ fn queue_status_callback(_queue_status: &Result<u32, String>) -> bool {
 }
 
 fn get_deployment(locator: &Locator) -> Result<String, String> {
-    let mut deployment_list_future = locator.get_deployment_list_async();
-    let deployment_list = deployment_list_future.get()?;
+    let deployment_list_future = locator.get_deployment_list_async();
+    let deployment_list = deployment_list_future.wait()?;
 
     if deployment_list.is_empty() {
         return Err("No deployments could be found!".to_owned());


### PR DESCRIPTION
Porting over the connection and deployment list futures over to use the `futures` crate.

TODO:
- [x] `DeploymentListFuture`