### PR TITLE
Update dependencies + fix Window build

### DIFF
--- a/spatialos-sdk-sys/build.rs
+++ b/spatialos-sdk-sys/build.rs
@@ -37,7 +37,7 @@ static PACKAGE_DIR: &str = "linux/lib";
 #[cfg(target_os = "macos")]
 static PACKAGE_DIR: &str = "macos/lib";
 #[cfg(target_os = "windows")]
-static PACKAGE_DIR: &str = "win/lib";
+static PACKAGE_DIR: &str = "win\\lib";
 
 fn main() {
     let lib_dir = match env::var("SPATIAL_LIB_DIR") {

--- a/spatialos-sdk-tools/Cargo.toml
+++ b/spatialos-sdk-tools/Cargo.toml
@@ -9,5 +9,5 @@ name = "download_sdk"
 path = "src/download_sdk/main.rs"
 
 [dependencies]
-zip = "0.4"
+zip = "0.5"
 clap = "2.32.0"


### PR DESCRIPTION
Found a bug where if you actually build using Windows (instead of WSL, whoops) the pathing was broken for finding the libraries.