### PR TITLE
Implement PartialEq for RequestId and make id private

### DIFF
--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -36,7 +36,7 @@ impl EntityId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialOrd, Ord)]
 pub struct RequestId<T> {
     pub id: u32,
     _type: PhantomData<*const T>,
@@ -52,6 +52,12 @@ impl<T> RequestId<T> {
 
     pub fn to_string(&self) -> String {
         format!("RequestId: {}", self.id)
+    }
+}
+
+impl<T> PartialEq for RequestId<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
     }
 }
 

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -13,8 +13,8 @@ pub mod snapshot;
 pub mod vtable;
 
 use spatialos_sdk_sys::worker::Worker_InterestOverride;
-use std::marker::PhantomData;
 use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
 
 type ComponentId = u32;
 

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -38,7 +38,7 @@ impl EntityId {
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialOrd, Ord)]
 pub struct RequestId<T> {
-    pub id: u32,
+    pub(crate) id: u32,
     _type: PhantomData<*const T>,
 }
 

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -14,6 +14,7 @@ pub mod vtable;
 
 use spatialos_sdk_sys::worker::Worker_InterestOverride;
 use std::marker::PhantomData;
+use std::hash::{Hash, Hasher};
 
 type ComponentId = u32;
 
@@ -36,7 +37,7 @@ impl EntityId {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord)]
 pub struct RequestId<T> {
     id: u32,
     _type: PhantomData<*const T>,
@@ -58,6 +59,12 @@ impl<T> RequestId<T> {
 impl<T> PartialEq for RequestId<T> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
+    }
+}
+
+impl<T> Hash for RequestId<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -38,7 +38,7 @@ impl EntityId {
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialOrd, Ord)]
 pub struct RequestId<T> {
-    pub(crate) id: u32,
+    id: u32,
     _type: PhantomData<*const T>,
 }
 


### PR DESCRIPTION
The derived implementation of `PartialEq` for `RequestId<T>` required that `T: PartialEq`, which means that you couldn't directly compare request IDs for most request types. Fortunately, we don't actually need that trait bound since the only thing we're comparing is `id`, so we can manually implement `PartialEq` in order to directly compare two `RequestId` objects.

On a related note, I've also made `RequestId::id` private, since we no longer need to access it directly in order to compare `RequestId`s. This improves encapsulation, and has the added advantage making `RequestId` more type-safe, since you can now only compare two `RequestId`s if they have the same type parameter (i.e. you can't compare a `RequestId<Foo>` and a `RequestId<Bar>`).