### PR TITLE
Custom derive traits for RequestId

### DIFF
--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
 edition = "2018"
 
 [dependencies]
+derivative = "1.0.2"
 spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
 futures = "0.1.25"
 

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -14,7 +14,9 @@ pub mod snapshot;
 pub mod vtable;
 
 use component::ComponentId;
+use derivative::Derivative;
 use spatialos_sdk_sys::worker::Worker_InterestOverride;
+use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
@@ -37,10 +39,30 @@ impl EntityId {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord)]
+#[derive(Derivative)]
+#[derivative(
+    Debug(bound = ""),
+    Copy(bound = ""),
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Hash(bound = "")
+)]
 pub struct RequestId<T> {
     id: u32,
     _type: PhantomData<*const T>,
+}
+
+impl<T> Ord for RequestId<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+impl<T> PartialOrd for RequestId<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 // SAFE: `RequestId<T>` is a type-safe wrapper around a single integer value, and is
@@ -54,18 +76,6 @@ impl<T> RequestId<T> {
             id,
             _type: PhantomData,
         }
-    }
-}
-
-impl<T> PartialEq for RequestId<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl<T> Hash for RequestId<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
     }
 }
 

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -17,7 +17,6 @@ use component::ComponentId;
 use derivative::Derivative;
 use spatialos_sdk_sys::worker::Worker_InterestOverride;
 use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -40,12 +40,11 @@ impl EntityId {
 #[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord)]
 pub struct RequestId<T> {
     id: u32,
-    _type: PhantomData<T>,
+    _type: PhantomData<*const T>,
 }
 
 // SAFE: `RequestId<T>` is a type-safe wrapper around a single integer value, and is
-// completely thread-safe. The manual impls here are only needed to ensure that the
-// implementation isn't bounded on `T: Send`/`T: Sync`.
+// therefore completely thread-safe.
 unsafe impl<T> Send for RequestId<T> {}
 unsafe impl<T> Sync for RequestId<T> {}
 

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -40,8 +40,14 @@ impl EntityId {
 #[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord)]
 pub struct RequestId<T> {
     id: u32,
-    _type: PhantomData<*const T>,
+    _type: PhantomData<T>,
 }
+
+// SAFE: `RequestId<T>` is a type-safe wrapper around a single integer value, and is
+// completely thread-safe. The manual impls here are only needed to ensure that the
+// implementation isn't bounded on `T: Send`/`T: Sync`.
+unsafe impl<T> Send for RequestId<T> {}
+unsafe impl<T> Sync for RequestId<T> {}
 
 impl<T> RequestId<T> {
     pub fn new(id: u32) -> RequestId<T> {
@@ -49,10 +55,6 @@ impl<T> RequestId<T> {
             id,
             _type: PhantomData,
         }
-    }
-
-    pub fn to_string(&self) -> String {
-        format!("RequestId: {}", self.id)
     }
 }
 


### PR DESCRIPTION
`RequestId<T>` wasn't being marked as `Send` or `Sync` because of the `PhantomData<*const T>` marker. I've manually implemented them, and left a comment explaining why the impls are safe.

I also removed `RequestId::to_string`, which seemed like an unnecessary helper function that's not being used? If there's a use case that's not covered by the `Debug` impl for `RequestId`, then let me know and we can figure out a more idiomatic solution 🙂 

---

UPDATE: I realized that this issue applies to all of the traits being derived for `RequestId`. Rather than manually implementing all the traits myself, I've pulled in the [derivative](https://mcarton.github.io/rust-derivative/) crate, which provides more configurable versions of the built in trait derives, including the ability to manually specify the generic bounds to use.