### PR TITLE
Implement Send for WorkerConnection

### DIFF
--- a/spatialos-sdk/examples/project-example/main.rs
+++ b/spatialos-sdk/examples/project-example/main.rs
@@ -84,7 +84,7 @@ fn logic_loop(c: &mut WorkerConnection) {
 fn exercise_connection_code_paths(c: &mut WorkerConnection) {
     c.send_log_message(LogLevel::Info, "main", "Connected successfully!", None);
     print_worker_attributes(&c);
-    check_for_flag(&c, "my-flag");
+    check_for_flag(c, "my-flag");
 
     let _ = c.get_op_list(0);
     c.send_reserve_entity_ids_request(ReserveEntityIdsRequest(1), None);
@@ -140,7 +140,7 @@ fn print_worker_attributes(connection: &WorkerConnection) {
     }
 }
 
-fn check_for_flag(connection: &WorkerConnection, flag_name: &str) {
+fn check_for_flag(connection: &mut WorkerConnection, flag_name: &str) {
     let flag = connection.get_worker_flag(flag_name);
     match flag {
         Some(f) => println!("Found flag value: {}", f),

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -490,6 +490,9 @@ impl Drop for WorkerConnection {
     }
 }
 
+// SAFE: The worker connection object is safe to send between threads.
+unsafe impl Send for WorkerConnection {}
+
 pub struct WorkerConnectionFuture {
     future_ptr: *mut Worker_ConnectionFuture,
     was_consumed: bool,


### PR DESCRIPTION
I'd like to propose that we mark `WorkerConnection` as `Send`. As I understand it, it should be perfectly fine to send the connection between threads, and marking it `Send` allows users to stick the connection object in a `Mutex` and share it between threads in a minimally-safe way. I can't really think of a reason why `WorkerConnection` wouldn't be safe to mark as `Send`, though I've [started a thread on the forums](https://forums.improbable.io/t/thread-safety-of-worker-connection-object/5358) to discuss the specifics of thread safety with the connection object.

If there's any reason why we shouldn't mark `WorkerConnection` as `Send`, please let me know! It's currently blocking me from integrating the SDK into Amethyst, since the connection object is effectively pinned to the thread that creates it.