### PR TITLE
Make WorkerConnection Send/Sync

### DIFF
--- a/spatialos-sdk/examples/project-example/main.rs
+++ b/spatialos-sdk/examples/project-example/main.rs
@@ -84,7 +84,7 @@ fn logic_loop(c: &mut WorkerConnection) {
 fn exercise_connection_code_paths(c: &mut WorkerConnection) {
     c.send_log_message(LogLevel::Info, "main", "Connected successfully!", None);
     print_worker_attributes(&c);
-    check_for_flag(&c, "my-flag");
+    check_for_flag(c, "my-flag");
 
     let _ = c.get_op_list(0);
     c.send_reserve_entity_ids_request(ReserveEntityIdsRequest(1), None);
@@ -140,7 +140,7 @@ fn print_worker_attributes(connection: &WorkerConnection) {
     }
 }
 
-fn check_for_flag(connection: &WorkerConnection, flag_name: &str) {
+fn check_for_flag(connection: &mut WorkerConnection, flag_name: &str) {
     let flag = connection.get_worker_flag(flag_name);
     match flag {
         Some(f) => println!("Found flag value: {}", f),

--- a/spatialos-sdk/src/lib.rs
+++ b/spatialos-sdk/src/lib.rs
@@ -1,3 +1,5 @@
 extern crate spatialos_sdk_sys;
 
 pub mod worker;
+
+mod ptr;

--- a/spatialos-sdk/src/lib.rs
+++ b/spatialos-sdk/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate spatialos_sdk_sys;
 
+pub(crate) mod ptr;
 pub mod worker;
-
-mod ptr;

--- a/spatialos-sdk/src/ptr.rs
+++ b/spatialos-sdk/src/ptr.rs
@@ -1,0 +1,30 @@
+//! Utilities for handling raw pointers.
+
+/// Wrapper around a raw pointer that ensures the pointer can only be accessed
+/// through `&mut self`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MutPtr<T> {
+    ptr: *mut T,
+}
+
+impl<T> MutPtr<T> {
+    pub fn new(ptr: *mut T) -> Self {
+        MutPtr { ptr }
+    }
+
+    /// Returns the raw pointer.
+    pub fn get(&mut self) -> *mut T {
+        self.ptr
+    }
+
+    /// Returns `true` if the pointer is null.
+    ///
+    /// Note that this only requires `&self` since it never dereferences the pointer. See the
+    /// primitive [`is_null`] method for more information about the general behavior of pointer
+    /// null checks.
+    ///
+    /// [`is_null`]: https://doc.rust-lang.org/std/primitive.pointer.html
+    pub fn is_null(&self) -> bool {
+        self.ptr.is_null()
+    }
+}

--- a/spatialos-sdk/src/ptr.rs
+++ b/spatialos-sdk/src/ptr.rs
@@ -1,13 +1,24 @@
 //! Utilities for handling raw pointers.
 
 /// Wrapper around a raw pointer that ensures the pointer can only be accessed
-/// through `&mut self`.
+/// through a mutable reference.
+///
+/// Some types in the C API can be safely shared between threads as long as they are
+/// only accessed by one thread at a time. We can enforce this invariant in Rust
+/// without a `Mutex` by requiring that the data be accessed only through a mutable
+/// reference. However, a `*mut T` doesn't follow Rust's usual ownership rules, and
+/// can still be used through a shared reference.
+///
+/// `MutPtr` wraps wraps a raw pointer and only allows the raw value to be accessed
+/// through a mutable reference, statically ensuring that the thread-safety
+/// requirements aren't violated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MutPtr<T> {
     ptr: *mut T,
 }
 
 impl<T> MutPtr<T> {
+    /// Creates a new `MutPtr` wrapping `ptr`.
     pub fn new(ptr: *mut T) -> Self {
         MutPtr { ptr }
     }

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -5,6 +5,7 @@ use futures::{Async, Future};
 
 use spatialos_sdk_sys::worker::*;
 
+use crate::ptr::MutPtr;
 use crate::worker::commands::*;
 use crate::worker::component;
 use crate::worker::component::internal::{CommandRequest, CommandResponse, ComponentUpdate};
@@ -15,7 +16,6 @@ use crate::worker::metrics::Metrics;
 use crate::worker::op::OpList;
 use crate::worker::parameters::{CommandParameters, ConnectionParameters};
 use crate::worker::{EntityId, InterestOverride, LogLevel, RequestId};
-use crate::ptr::MutPtr;
 
 #[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
 pub enum ConnectionStatusCode {

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -490,6 +490,9 @@ impl Drop for WorkerConnection {
     }
 }
 
+// SAFE: The worker connection object is safe to send between threads.
+unsafe impl Send for WorkerConnection {}
+
 pub struct WorkerConnectionFuture {
     future_ptr: *mut Worker_ConnectionFuture,
     was_consumed: bool,

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -15,6 +15,7 @@ use crate::worker::metrics::Metrics;
 use crate::worker::op::OpList;
 use crate::worker::parameters::{CommandParameters, ConnectionParameters};
 use crate::worker::{EntityId, InterestOverride, LogLevel, RequestId};
+use crate::ptr::MutPtr;
 
 #[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
 pub enum ConnectionStatusCode {
@@ -135,34 +136,6 @@ pub trait Connection {
     fn get_worker_id(&self) -> &str;
 
     fn get_worker_attributes(&self) -> &[String];
-}
-
-/// Wrapper around a raw pointer that ensures the pointer can only be accessed through `&mut self`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct MutPtr<T> {
-    ptr: *mut T,
-}
-
-impl<T> MutPtr<T> {
-    pub fn new(ptr: *mut T) -> Self {
-        MutPtr { ptr }
-    }
-
-    /// Returns the raw pointer.
-    pub fn get(&mut self) -> *mut T {
-        self.ptr
-    }
-
-    /// Returns `true` if the pointer is null.
-    /// 
-    /// Note that this only requires `&self` since it never dereferences the pointer. See the
-    /// primitive [`is_null`] method for more information about the general behavior of pointer
-    /// null checks.
-    /// 
-    /// [`is_null`]: https://doc.rust-lang.org/std/primitive.pointer.html
-    pub fn is_null(&self) -> bool {
-        self.ptr.is_null()
-    }
 }
 
 pub struct WorkerConnection {


### PR DESCRIPTION
Based on what [Alastair said on the forums](https://forums.improbable.io/t/thread-safety-of-worker-connection-object/5358/2?u=randompoison), the worker connection should be safe to share between threads if wrapped in a mutex. For our purposes, that means that `WorkerConnection` is already `Send`, which is all we need to wrap it in a `Mutex` and start sharing it between threads. Fortunately, with some minor adjustments, `WorkerConnection` can also be made `Sync`, which enables a wider variety threading models for managing the connection.

So long as we always access the underlying `*mut Worker_Connection` pointer through `&mut self`, Rust's ownership system will guarantee that only one thread has access to the connection at a time. So all we should need in order to safely implement `Sync` for `WorkerConnection` is to change any methods that access the raw pointer to take `&mut self`. I've made this change, and I've added the `MutPtr<T>` wrapper type to enforce statically that all methods accessing the pointer have to take `&mut self`.

Additionally, there are two pieces of connection data that *should* be safe to access concurrently from multiple threads: The worker ID and worker attributes. The C API currently doesn't guarantee that the methods for retrieving this data are safe to call concurrently, however the data is static for the lifetime of the connection, so we can retrieve it once at startup and cache it in `WorkerConnection`. Once the data is cached at the Rust level, we can use Rust's normal safety guarantees to allow us to access that data through a `&self` (and therefore allow it to be accessed concurrently from multiple threads).
