### PR TITLE
Implement command request/response methods

### DIFF
--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -186,13 +186,7 @@ impl Component for <#= self.rust_name(&component.identifier) #> {
     }
 
     fn to_request(request: &<#= self.rust_fqname(&component.identifier) #>CommandRequest) -> Result<SchemaCommandRequest, String> {
-        let command_index = match request {<#
-            for command in &component.command_definitions {
-            #>
-            <#= self.rust_name(&component.identifier) #>CommandRequest::<#= command.identifier.name.to_camel_case() #>(_) => <#= command.command_index #>,<# } #>
-            _ => unreachable!()
-        };
-        let mut serialized_request = SchemaCommandRequest::new(Self::ID, command_index);
+        let mut serialized_request = SchemaCommandRequest::new(Self::ID, Self::get_request_command_index(request));
         match request {<#
             for command in &component.command_definitions {
             #>
@@ -205,13 +199,7 @@ impl Component for <#= self.rust_name(&component.identifier) #> {
     }
 
     fn to_response(response: &<#= self.rust_fqname(&component.identifier) #>CommandResponse) -> Result<SchemaCommandResponse, String> {
-        let command_index = match response {<#
-            for command in &component.command_definitions {
-            #>
-            <#= self.rust_name(&component.identifier) #>CommandResponse::<#= command.identifier.name.to_camel_case() #>(_) => <#= command.command_index #>,<# } #>
-            _ => unreachable!()
-        };
-        let mut serialized_response = SchemaCommandResponse::new(Self::ID, command_index);
+        let mut serialized_response = SchemaCommandResponse::new(Self::ID, Self::get_response_command_index(response));
         match response {<#
             for command in &component.command_definitions {
             #>
@@ -221,6 +209,24 @@ impl Component for <#= self.rust_name(&component.identifier) #> {
             _ => unreachable!()
         }
         Ok(serialized_response)
+    }
+
+    fn get_request_command_index(request: &<#= self.rust_fqname(&component.identifier) #>CommandRequest) -> u32 {
+        match request {<#
+            for command in &component.command_definitions {
+            #>
+            <#= self.rust_name(&component.identifier) #>CommandRequest::<#= command.identifier.name.to_camel_case() #>(_) => <#= command.command_index #>,<# } #>
+            _ => unreachable!(),
+        }
+    }
+
+    fn get_response_command_index(response: &<#= self.rust_fqname(&component.identifier) #>CommandResponse) -> u32 {
+        match response {<#
+            for command in &component.command_definitions {
+            #>
+            <#= self.rust_name(&component.identifier) #>CommandResponse::<#= command.identifier.name.to_camel_case() #>(_) => <#= command.command_index #>,<# } #>
+            _ => unreachable!(),
+        }
     }
 }
 <# } #>

--- a/spatialos-sdk/examples/project-example/generated_code.rs
+++ b/spatialos-sdk/examples/project-example/generated_code.rs
@@ -171,11 +171,8 @@ mod generated {
             fn to_request(
                 request: &generated::example::ExampleCommandRequest,
             ) -> Result<SchemaCommandRequest, String> {
-                let command_index = match request {
-                    ExampleCommandRequest::TestCommand(_) => 1,
-                    _ => unreachable!(),
-                };
-                let mut serialized_request = SchemaCommandRequest::new(Self::ID, command_index);
+                let mut serialized_request =
+                    SchemaCommandRequest::new(Self::ID, Self::get_request_command_index(request));
                 match request {
                     ExampleCommandRequest::TestCommand(ref data) => {
                         <generated::example::CommandData as TypeConversion>::to_type(
@@ -191,11 +188,10 @@ mod generated {
             fn to_response(
                 response: &generated::example::ExampleCommandResponse,
             ) -> Result<SchemaCommandResponse, String> {
-                let command_index = match response {
-                    ExampleCommandResponse::TestCommand(_) => 1,
-                    _ => unreachable!(),
-                };
-                let mut serialized_response = SchemaCommandResponse::new(Self::ID, command_index);
+                let mut serialized_response = SchemaCommandResponse::new(
+                    Self::ID,
+                    Self::get_response_command_index(response),
+                );
                 match response {
                     ExampleCommandResponse::TestCommand(ref data) => {
                         <generated::example::CommandData as TypeConversion>::to_type(
@@ -206,6 +202,24 @@ mod generated {
                     _ => unreachable!(),
                 }
                 Ok(serialized_response)
+            }
+
+            fn get_request_command_index(
+                request: &generated::example::ExampleCommandRequest,
+            ) -> u32 {
+                match request {
+                    ExampleCommandRequest::TestCommand(_) => 1,
+                    _ => unreachable!(),
+                }
+            }
+
+            fn get_response_command_index(
+                response: &generated::example::ExampleCommandResponse,
+            ) -> u32 {
+                match response {
+                    ExampleCommandResponse::TestCommand(_) => 1,
+                    _ => unreachable!(),
+                }
             }
         }
 
@@ -857,10 +871,8 @@ mod generated {
             fn to_request(
                 request: &generated::improbable::EntityAclCommandRequest,
             ) -> Result<SchemaCommandRequest, String> {
-                let command_index = match request {
-                    _ => unreachable!(),
-                };
-                let mut serialized_request = SchemaCommandRequest::new(Self::ID, command_index);
+                let mut serialized_request =
+                    SchemaCommandRequest::new(Self::ID, Self::get_request_command_index(request));
                 match request {
                     _ => unreachable!(),
                 }
@@ -870,14 +882,30 @@ mod generated {
             fn to_response(
                 response: &generated::improbable::EntityAclCommandResponse,
             ) -> Result<SchemaCommandResponse, String> {
-                let command_index = match response {
-                    _ => unreachable!(),
-                };
-                let mut serialized_response = SchemaCommandResponse::new(Self::ID, command_index);
+                let mut serialized_response = SchemaCommandResponse::new(
+                    Self::ID,
+                    Self::get_response_command_index(response),
+                );
                 match response {
                     _ => unreachable!(),
                 }
                 Ok(serialized_response)
+            }
+
+            fn get_request_command_index(
+                request: &generated::improbable::EntityAclCommandRequest,
+            ) -> u32 {
+                match request {
+                    _ => unreachable!(),
+                }
+            }
+
+            fn get_response_command_index(
+                response: &generated::improbable::EntityAclCommandResponse,
+            ) -> u32 {
+                match response {
+                    _ => unreachable!(),
+                }
             }
         }
 
@@ -1033,10 +1061,8 @@ mod generated {
             fn to_request(
                 request: &generated::improbable::InterestCommandRequest,
             ) -> Result<SchemaCommandRequest, String> {
-                let command_index = match request {
-                    _ => unreachable!(),
-                };
-                let mut serialized_request = SchemaCommandRequest::new(Self::ID, command_index);
+                let mut serialized_request =
+                    SchemaCommandRequest::new(Self::ID, Self::get_request_command_index(request));
                 match request {
                     _ => unreachable!(),
                 }
@@ -1046,14 +1072,30 @@ mod generated {
             fn to_response(
                 response: &generated::improbable::InterestCommandResponse,
             ) -> Result<SchemaCommandResponse, String> {
-                let command_index = match response {
-                    _ => unreachable!(),
-                };
-                let mut serialized_response = SchemaCommandResponse::new(Self::ID, command_index);
+                let mut serialized_response = SchemaCommandResponse::new(
+                    Self::ID,
+                    Self::get_response_command_index(response),
+                );
                 match response {
                     _ => unreachable!(),
                 }
                 Ok(serialized_response)
+            }
+
+            fn get_request_command_index(
+                request: &generated::improbable::InterestCommandRequest,
+            ) -> u32 {
+                match request {
+                    _ => unreachable!(),
+                }
+            }
+
+            fn get_response_command_index(
+                response: &generated::improbable::InterestCommandResponse,
+            ) -> u32 {
+                match response {
+                    _ => unreachable!(),
+                }
             }
         }
 
@@ -1177,10 +1219,8 @@ mod generated {
             fn to_request(
                 request: &generated::improbable::MetadataCommandRequest,
             ) -> Result<SchemaCommandRequest, String> {
-                let command_index = match request {
-                    _ => unreachable!(),
-                };
-                let mut serialized_request = SchemaCommandRequest::new(Self::ID, command_index);
+                let mut serialized_request =
+                    SchemaCommandRequest::new(Self::ID, Self::get_request_command_index(request));
                 match request {
                     _ => unreachable!(),
                 }
@@ -1190,14 +1230,30 @@ mod generated {
             fn to_response(
                 response: &generated::improbable::MetadataCommandResponse,
             ) -> Result<SchemaCommandResponse, String> {
-                let command_index = match response {
-                    _ => unreachable!(),
-                };
-                let mut serialized_response = SchemaCommandResponse::new(Self::ID, command_index);
+                let mut serialized_response = SchemaCommandResponse::new(
+                    Self::ID,
+                    Self::get_response_command_index(response),
+                );
                 match response {
                     _ => unreachable!(),
                 }
                 Ok(serialized_response)
+            }
+
+            fn get_request_command_index(
+                request: &generated::improbable::MetadataCommandRequest,
+            ) -> u32 {
+                match request {
+                    _ => unreachable!(),
+                }
+            }
+
+            fn get_response_command_index(
+                response: &generated::improbable::MetadataCommandResponse,
+            ) -> u32 {
+                match response {
+                    _ => unreachable!(),
+                }
             }
         }
 
@@ -1298,10 +1354,8 @@ mod generated {
             fn to_request(
                 request: &generated::improbable::PersistenceCommandRequest,
             ) -> Result<SchemaCommandRequest, String> {
-                let command_index = match request {
-                    _ => unreachable!(),
-                };
-                let mut serialized_request = SchemaCommandRequest::new(Self::ID, command_index);
+                let mut serialized_request =
+                    SchemaCommandRequest::new(Self::ID, Self::get_request_command_index(request));
                 match request {
                     _ => unreachable!(),
                 }
@@ -1311,14 +1365,30 @@ mod generated {
             fn to_response(
                 response: &generated::improbable::PersistenceCommandResponse,
             ) -> Result<SchemaCommandResponse, String> {
-                let command_index = match response {
-                    _ => unreachable!(),
-                };
-                let mut serialized_response = SchemaCommandResponse::new(Self::ID, command_index);
+                let mut serialized_response = SchemaCommandResponse::new(
+                    Self::ID,
+                    Self::get_response_command_index(response),
+                );
                 match response {
                     _ => unreachable!(),
                 }
                 Ok(serialized_response)
+            }
+
+            fn get_request_command_index(
+                request: &generated::improbable::PersistenceCommandRequest,
+            ) -> u32 {
+                match request {
+                    _ => unreachable!(),
+                }
+            }
+
+            fn get_response_command_index(
+                response: &generated::improbable::PersistenceCommandResponse,
+            ) -> u32 {
+                match response {
+                    _ => unreachable!(),
+                }
             }
         }
 
@@ -1454,10 +1524,8 @@ mod generated {
             fn to_request(
                 request: &generated::improbable::PositionCommandRequest,
             ) -> Result<SchemaCommandRequest, String> {
-                let command_index = match request {
-                    _ => unreachable!(),
-                };
-                let mut serialized_request = SchemaCommandRequest::new(Self::ID, command_index);
+                let mut serialized_request =
+                    SchemaCommandRequest::new(Self::ID, Self::get_request_command_index(request));
                 match request {
                     _ => unreachable!(),
                 }
@@ -1467,14 +1535,30 @@ mod generated {
             fn to_response(
                 response: &generated::improbable::PositionCommandResponse,
             ) -> Result<SchemaCommandResponse, String> {
-                let command_index = match response {
-                    _ => unreachable!(),
-                };
-                let mut serialized_response = SchemaCommandResponse::new(Self::ID, command_index);
+                let mut serialized_response = SchemaCommandResponse::new(
+                    Self::ID,
+                    Self::get_response_command_index(response),
+                );
                 match response {
                     _ => unreachable!(),
                 }
                 Ok(serialized_response)
+            }
+
+            fn get_request_command_index(
+                request: &generated::improbable::PositionCommandRequest,
+            ) -> u32 {
+                match request {
+                    _ => unreachable!(),
+                }
+            }
+
+            fn get_response_command_index(
+                response: &generated::improbable::PositionCommandResponse,
+            ) -> u32 {
+                match response {
+                    _ => unreachable!(),
+                }
             }
         }
 

--- a/spatialos-sdk/src/worker/commands.rs
+++ b/spatialos-sdk/src/worker/commands.rs
@@ -1,5 +1,57 @@
 use crate::worker::query::EntityQuery;
 use crate::worker::EntityId;
+use spatialos_sdk_sys::worker::Worker_CommandParameters;
+
+/// Additional parameters for sending command requests.
+///
+/// Additional parameters passed to [`Connection::send_command_request`]. Note that all
+/// parameters are kept private and the struct can only be initialized with default
+/// values in order to make it possible to add new parameters without a breaking change.
+///
+/// If you would like to use a method-chaining style when initializing the parameters,
+/// the [tap] crate is recommended. The examples below demonstrate this.
+///
+/// # Parameters
+///
+/// * `allow_short_circuit: false` allow the command to skip being routed through SpatialOS if
+///   the worker is sending a command to itself. This avoids a round trip, but
+///   SpatialOS cannot guarantee that the command will be fully delivered and executed.
+///   [See the docs for mroe information.][short-circuit]
+///
+/// # Examples
+///
+/// ```
+/// use spatialos_sdk::worker::commands::CommandParameters;
+/// use tap::*;
+///
+/// let params = CommandParameters::new()
+///     .tap(CommandParameters::allow_short_circuit);
+/// ```
+///
+/// [short-circuit]: https://docs.improbable.io/reference/13.5/shared/design/commands#properties
+/// [tap]: https://crates.io/crates/tap
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct CommandParameters {
+    allow_short_circuit: bool,
+}
+
+impl CommandParameters {
+    /// Creates a new `CommandParameters` with default values for all parameters.
+    pub fn new() -> CommandParameters {
+        Default::default()
+    }
+
+    /// Sets the `allow_short_circuit` parameter to `true`.
+    pub fn allow_short_circuit(&mut self) {
+        self.allow_short_circuit = true;
+    }
+
+    pub(crate) fn to_worker_sdk(&self) -> Worker_CommandParameters {
+        Worker_CommandParameters {
+            allow_short_circuit: self.allow_short_circuit as u8,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct IncomingCommandRequest {}

--- a/spatialos-sdk/src/worker/commands.rs
+++ b/spatialos-sdk/src/worker/commands.rs
@@ -16,7 +16,7 @@ use spatialos_sdk_sys::worker::Worker_CommandParameters;
 /// * `allow_short_circuit: false` allow the command to skip being routed through SpatialOS if
 ///   the worker is sending a command to itself. This avoids a round trip, but
 ///   SpatialOS cannot guarantee that the command will be fully delivered and executed.
-///   [See the docs for mroe information.][short-circuit]
+///   [See the docs for more information.][short-circuit]
 ///
 /// # Examples
 ///

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -43,9 +43,14 @@ where
     ) -> Result<Self::CommandResponse, String>;
 
     fn to_data(data: &Self) -> Result<schema::SchemaComponentData, String>;
-    fn to_update(data: &Self::Update) -> Result<schema::SchemaComponentUpdate, String>;
-    fn to_request(data: &Self::CommandRequest) -> Result<schema::SchemaCommandRequest, String>;
-    fn to_response(data: &Self::CommandResponse) -> Result<schema::SchemaCommandResponse, String>;
+    fn to_update(update: &Self::Update) -> Result<schema::SchemaComponentUpdate, String>;
+    fn to_request(request: &Self::CommandRequest) -> Result<schema::SchemaCommandRequest, String>;
+    fn to_response(
+        response: &Self::CommandResponse,
+    ) -> Result<schema::SchemaCommandResponse, String>;
+
+    fn get_request_command_index(request: &Self::CommandRequest) -> u32;
+    fn get_response_command_index(response: &Self::CommandResponse) -> u32;
 }
 
 // Internal untyped component data objects.

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -332,6 +332,8 @@ impl Connection for WorkerConnection {
         timeout_millis: Option<u32>,
         allow_short_circuit: bool,
     ) -> RequestId<OutgoingCommandRequest> {
+        let command_index = C::get_request_command_index(&request);
+
         let timeout = match timeout_millis {
             Some(c) => &c,
             None => ptr::null(),
@@ -353,7 +355,7 @@ impl Connection for WorkerConnection {
                 self.connection_ptr,
                 entity_id.id,
                 &command_request,
-                0,
+                command_index,
                 timeout,
                 &params,
             )

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -87,7 +87,7 @@ pub trait Connection {
         entity_id: EntityId,
         request: C::CommandRequest,
         timeout_millis: Option<u32>,
-        allow_short_circuit: bool,
+        params: CommandParameters,
     ) -> RequestId<OutgoingCommandRequest>;
 
     fn send_command_response<C: Component>(
@@ -330,7 +330,7 @@ impl Connection for WorkerConnection {
         entity_id: EntityId,
         request: C::CommandRequest,
         timeout_millis: Option<u32>,
-        allow_short_circuit: bool,
+        params: CommandParameters,
     ) -> RequestId<OutgoingCommandRequest> {
         let command_index = C::get_request_command_index(&request);
 
@@ -346,10 +346,6 @@ impl Connection for WorkerConnection {
             user_handle: component::handle_allocate(request),
         };
 
-        let params = Worker_CommandParameters {
-            allow_short_circuit: allow_short_circuit as _,
-        };
-
         let request_id = unsafe {
             Worker_Connection_SendCommandRequest(
                 self.connection_ptr,
@@ -357,7 +353,7 @@ impl Connection for WorkerConnection {
                 &command_request,
                 command_index,
                 timeout,
-                &params,
+                &params.to_worker_sdk(),
             )
         };
 

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -6,7 +6,7 @@ use futures::{Async, Future};
 use spatialos_sdk_sys::worker::*;
 
 use crate::worker::commands::*;
-use crate::worker::component::internal::{CommandRequest, CommandResponse, ComponentUpdate};
+use crate::worker::component::internal::ComponentUpdate;
 use crate::worker::component::{self, Component};
 use crate::worker::entity::Entity;
 use crate::worker::internal::utils::cstr_to_string;

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -1,18 +1,21 @@
 use crate::ptr::MutPtr;
-use crate::worker::commands::*;
-use crate::worker::component::internal::ComponentUpdate;
-use crate::worker::component::{self, Component};
-use crate::worker::entity::Entity;
-use crate::worker::internal::utils::cstr_to_string;
-use crate::worker::locator::*;
-use crate::worker::metrics::Metrics;
-use crate::worker::op::OpList;
-use crate::worker::parameters::ConnectionParameters;
-use crate::worker::{EntityId, InterestOverride, LogLevel, RequestId};
+use crate::worker::{
+    commands::*,
+    component::{self, internal::ComponentUpdate, Component},
+    entity::Entity,
+    internal::utils::cstr_to_string,
+    locator::*,
+    metrics::Metrics,
+    op::OpList,
+    parameters::ConnectionParameters,
+    {EntityId, InterestOverride, LogLevel, RequestId},
+};
 use futures::{Async, Future};
 use spatialos_sdk_sys::worker::*;
-use std::ffi::{CStr, CString, NulError};
-use std::ptr;
+use std::{
+    ffi::{CStr, CString, NulError},
+    ptr,
+};
 
 /// Information about the status of a worker connection or network request.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/spatialos-sdk/src/worker/parameters.rs
+++ b/spatialos-sdk/src/worker/parameters.rs
@@ -389,19 +389,12 @@ impl ThreadAffinityParameters {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CommandParameters {
     allow_short_circuit: bool,
 }
 
 impl CommandParameters {
-    const SHORT_CIRCUIT: CommandParameters = CommandParameters {
-        allow_short_circuit: true,
-    };
-
-    const DEFAULT: CommandParameters = CommandParameters {
-        allow_short_circuit: false,
-    };
-
     pub fn new(should_short_circuit: bool) -> CommandParameters {
         CommandParameters {
             allow_short_circuit: should_short_circuit,

--- a/spatialos-sdk/src/worker/parameters.rs
+++ b/spatialos-sdk/src/worker/parameters.rs
@@ -389,25 +389,6 @@ impl ThreadAffinityParameters {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CommandParameters {
-    allow_short_circuit: bool,
-}
-
-impl CommandParameters {
-    pub fn new(should_short_circuit: bool) -> CommandParameters {
-        CommandParameters {
-            allow_short_circuit: should_short_circuit,
-        }
-    }
-
-    pub(crate) fn to_worker_sdk(&self) -> Worker_CommandParameters {
-        Worker_CommandParameters {
-            allow_short_circuit: self.allow_short_circuit as u8,
-        }
-    }
-}
-
 pub struct SnapshotParameters {}
 
 impl SnapshotParameters {


### PR DESCRIPTION
* Implement `send_command_request`, `send_command_response`, and `send_command_error` on `WorkerConnection`.
* Have `send_command_error` return a `Result<(), NulError>` in case the user passes in a message that can't be safely converted to a C string.
* Remove `CommandParameters`, opting to pass the `allow_short_circuit` option directly to `send_command_request`.