### PR TITLE
Rust 1.34 breaking changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
   allow_failures:
     - os: windows
     - rust: nightly
+    - rust: beta
 
 before_install:
 - set -e


### PR DESCRIPTION
The Rust 1.33 release means the 1.34 beta is live and..

Looks like the beta version of 1.34 has some breaking changes in Clippy which perscribe: 

```
error: redundant closure found
   --> spatialos-sdk/src/worker/connection.rs:484:18
    |
484 |             .map(|x| x.to_worker_sdk())
    |                  ^^^^^^^^^^^^^^^^^^^^^ help: remove closure as shown: `worker::InterestOverride::to_worker_sdk`
    |
    = note: `-D clippy::redundant-closure` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
error: redundant closure found
   --> spatialos-sdk/src/worker/query.rs:252:26
    |
252 |                     .map(|x| x.constraint_len_recursive())
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove closure as shown: `worker::query::QueryConstraint::constraint_len_recursive`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
```

but making these changes on stable leads to:

```
error[E0277]: a collection of type `std::vec::Vec<spatialos_sdk_sys::worker::Worker_InterestOverride>` cannot be built from an iterator over elements of type `for<'r> fn(&'r worker::InterestOverride) -> spatialos_sdk_sys::worker::Worker_InterestOverride {worker::InterestOverride::to_worker_sdk}`
   --> spatialos-sdk\src\worker\connection.rs:485:14
    |
485 |             .collect::<Vec<Worker_InterestOverride>>();
    |              ^^^^^^^ a collection of type `std::vec::Vec<spatialos_sdk_sys::worker::Worker_InterestOverride>` cannot be built from `std::iter::Iterator<Item=for<'r> fn(&'r worker::InterestOverride) -> spatialos_sdk_sys::worker::Worker_InterestOverride {worker::InterestOverride::to_worker_sdk}>`
    |
    = help: the trait `std::iter::FromIterator<for<'r> fn(&'r worker::InterestOverride) -> spatialos_sdk_sys::worker::Worker_InterestOverride {worker::InterestOverride::to_worker_sdk}>` is not implemented for `std::vec::Vec<spatialos_sdk_sys::worker::Worker_InterestOverride>`

error[E0277]: the trait bound `u32: std::iter::Sum<for<'r> fn(&'r worker::query::QueryConstraint) -> u32 {worker::query::QueryConstraint::constraint_len_recursive}>` is not satisfied
   --> spatialos-sdk\src\worker\query.rs:253:22
    |
253 |                     .sum::<u32>()
    |                      ^^^ the trait `std::iter::Sum<for<'r> fn(&'r worker::query::QueryConstraint) -> u32 {worker::query::QueryConstraint::constraint_len_recursive}>` is not implemented for `u32`
    |
    = help: the following implementations were found:
              <u32 as std::iter::Sum<&'a u32>>
              <u32 as std::iter::Sum>

error: aborting due to 2 previous errors
```

In the interests of CI being a good signal, beta builds are _allowed_ to fail until a better solution is found 