### PR TITLE
Use inventory for automatic component registration 

### DIFF
--- a/project-example/Cargo.toml
+++ b/project-example/Cargo.toml
@@ -14,4 +14,3 @@ uuid = { version = "0.7", features = ["v4"] }
 structopt = "0.2.14"
 rand = "0.6.5"
 tap = "0.3.0"
-inventory = "0.1"

--- a/project-example/Cargo.toml
+++ b/project-example/Cargo.toml
@@ -14,3 +14,4 @@ uuid = { version = "0.7", features = ["v4"] }
 structopt = "0.2.14"
 rand = "0.6.5"
 tap = "0.3.0"
+inventory = "0.1"

--- a/project-example/rust_client.json
+++ b/project-example/rust_client.json
@@ -1,10 +1,6 @@
 {
   "workerType": "RustClient",
-  "attributeSet": {
-    "attributes": [
-      "rusty-client"
-    ]
-  },
+  "layer": "client",
   "entity_interest": {
     "range_entity_interest": {
       "radius": 2

--- a/project-example/src/connection_handler.rs
+++ b/project-example/src/connection_handler.rs
@@ -30,7 +30,7 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
             let params = ConnectionParameters::new(worker_type)
                 .using_tcp()
                 .using_external_ip(connect_with_external_ip)
-                .generate_component_vtable();
+                .enable_internal_serialization();
             WorkerConnection::connect_receptionist_async(
                 &worker_id,
                 &host.unwrap_or_else(|| "127.0.0.1".into()),
@@ -53,7 +53,7 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
                 &ConnectionParameters::new(worker_type)
                     .using_tcp()
                     .using_external_ip(true)
-                    .generate_component_vtable(),
+                    .enable_internal_serialization(),
                 queue_status_callback,
             )
         }
@@ -97,7 +97,7 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
                 &ConnectionParameters::new(worker_type)
                     .using_tcp()
                     .using_external_ip(true)
-                    .generate_component_vtable(),
+                    .enable_internal_serialization(),
             )
         }
     };

--- a/project-example/src/connection_handler.rs
+++ b/project-example/src/connection_handler.rs
@@ -2,7 +2,6 @@ use crate::{Command, Opt};
 use futures::{Async, Future};
 use spatialos_sdk::worker::{
     alpha::{self, LoginTokensRequest, PlayerIdentityCredentials, PlayerIdentityTokenRequest},
-    component::ComponentDatabase,
     connection::{WorkerConnection, WorkerConnectionFuture},
     constants::{LOCATOR_HOSTNAME, LOCATOR_PORT, RECEPTIONIST_PORT},
     locator::{Locator, LocatorCredentials, LocatorParameters},
@@ -13,7 +12,7 @@ use uuid::Uuid;
 const POLL_NUM_ATTEMPTS: u32 = 5;
 const POLL_TIME_BETWEEN_ATTEMPTS_MILLIS: u64 = 3000;
 
-pub fn get_connection(opt: Opt, components: ComponentDatabase) -> Result<WorkerConnection, String> {
+pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
     let Opt {
         worker_type,
         worker_id,
@@ -28,9 +27,10 @@ pub fn get_connection(opt: Opt, components: ComponentDatabase) -> Result<WorkerC
             port,
             connect_with_external_ip,
         } => {
-            let params = ConnectionParameters::new(worker_type, components)
+            let params = ConnectionParameters::new(worker_type)
                 .using_tcp()
-                .using_external_ip(connect_with_external_ip);
+                .using_external_ip(connect_with_external_ip)
+                .generate_component_vtable();
             WorkerConnection::connect_receptionist_async(
                 &worker_id,
                 &host.unwrap_or_else(|| "127.0.0.1".into()),
@@ -50,9 +50,10 @@ pub fn get_connection(opt: Opt, components: ComponentDatabase) -> Result<WorkerC
             WorkerConnection::connect_locator_async(
                 &locator,
                 &deployment,
-                &ConnectionParameters::new(worker_type, components)
+                &ConnectionParameters::new(worker_type)
                     .using_tcp()
-                    .using_external_ip(true),
+                    .using_external_ip(true)
+                    .generate_component_vtable(),
                 queue_status_callback,
             )
         }
@@ -93,9 +94,10 @@ pub fn get_connection(opt: Opt, components: ComponentDatabase) -> Result<WorkerC
 
             WorkerConnection::connect_alpha_locator_async(
                 &alpha_locator,
-                &ConnectionParameters::new(worker_type, components)
+                &ConnectionParameters::new(worker_type)
                     .using_tcp()
-                    .using_external_ip(true),
+                    .using_external_ip(true)
+                    .generate_component_vtable(),
             )
         }
     };

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -24,16 +24,8 @@ mod generated;
 mod opt;
 
 fn main() {
-    println!("Entered program");
 
-    let components = ComponentDatabase::new()
-        .add_component::<example::Example>()
-        .add_component::<example::Rotate>()
-        .add_component::<improbable::EntityAcl>()
-        .add_component::<improbable::Persistence>()
-        .add_component::<improbable::Metadata>()
-        .add_component::<improbable::Interest>()
-        .add_component::<improbable::Position>();
+    let components = ComponentDatabase::new();
 
     let opt = Opt::from_args();
     let mut worker_connection = match get_connection(opt, components) {

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -3,7 +3,7 @@ use generated::{example, improbable};
 use rand::Rng;
 use spatialos_sdk::worker::{
     commands::{EntityQueryRequest, ReserveEntityIdsRequest},
-    component::{Component, ComponentData, ComponentDatabase, UpdateParameters},
+    component::{Component, ComponentData, UpdateParameters},
     connection::{Connection, WorkerConnection},
     entity::Entity,
     metrics::{HistogramMetric, Metrics},
@@ -24,11 +24,8 @@ mod generated;
 mod opt;
 
 fn main() {
-
-    let components = ComponentDatabase::new();
-
     let opt = Opt::from_args();
-    let mut worker_connection = match get_connection(opt, components) {
+    let mut worker_connection = match get_connection(opt) {
         Ok(c) => c,
         Err(e) => panic!("{}", e),
     };

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -229,4 +229,6 @@ impl Component for <#= self.rust_name(&component.identifier) #> {
         }
     }
 }
+
+inventory::submit!(WrappedVTable::new(create_component_vtable::<<#= self.rust_name(&component.identifier) #>>()));
 <# } #>

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -230,5 +230,5 @@ impl Component for <#= self.rust_name(&component.identifier) #> {
     }
 }
 
-inventory::submit!(WrappedVTable::new(create_component_vtable::<<#= self.rust_name(&component.identifier) #>>()));
+inventory::submit!(VTable::new::<<#= self.rust_name(&component.identifier) #>>());
 <# } #>

--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 derivative = "1.0.2"
 spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
 futures = "0.1.25"
+inventory = "0.1"
 
 [dev-dependencies]
 uuid = { version = "0.7", features = ["v4"] }

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -228,7 +228,7 @@ pub(crate) mod internal {
     }
 }
 
-inventory::collect!(WrappedVTable);
+inventory::collect!(VTable);
 
 // A data structure which represents all known component types. Used to generate an array of vtables to pass
 // to the connection object.
@@ -240,14 +240,13 @@ pub struct ComponentDatabase {
 impl ComponentDatabase {
     pub fn new() -> Self {
         let mut vtables = Vec::new();
-        for table in inventory::iter::<WrappedVTable> {
+        for table in inventory::iter::<VTable> {
             vtables.push(table.vtable)
         }
 
         ComponentDatabase {
             component_vtables: vtables,
         }
-
     }
 
     pub(crate) fn to_worker_sdk(&self) -> *const Worker_ComponentVtable {
@@ -274,39 +273,34 @@ pub(crate) unsafe fn handle_copy<T>(handle: *mut raw::c_void) -> *mut raw::c_voi
     Arc::into_raw(copy) as *mut _
 }
 
-pub struct WrappedVTable {
-    vtable: Worker_ComponentVtable
+pub struct VTable {
+    vtable: Worker_ComponentVtable,
 }
 
-impl WrappedVTable {
-    pub fn new(vtable: Worker_ComponentVtable) -> Self {
-        WrappedVTable {
-            vtable
+impl VTable {
+    pub fn new<C: Component>() -> Self {
+        VTable {
+            vtable: Worker_ComponentVtable {
+                component_id: C::ID,
+                user_data: ptr::null_mut(),
+                command_request_free: Some(vtable_command_request_free::<C>),
+                command_request_copy: Some(vtable_command_request_copy::<C>),
+                command_request_deserialize: Some(vtable_command_request_deserialize::<C>),
+                command_request_serialize: Some(vtable_command_request_serialize::<C>),
+                command_response_free: Some(vtable_command_response_free::<C>),
+                command_response_copy: Some(vtable_command_response_copy::<C>),
+                command_response_deserialize: Some(vtable_command_response_deserialize::<C>),
+                command_response_serialize: Some(vtable_command_response_serialize::<C>),
+                component_data_free: Some(vtable_component_data_free::<C>),
+                component_data_copy: Some(vtable_component_data_copy::<C>),
+                component_data_deserialize: Some(vtable_component_data_deserialize::<C>),
+                component_data_serialize: Some(vtable_component_data_serialize::<C>),
+                component_update_free: Some(vtable_component_update_free::<C>),
+                component_update_copy: Some(vtable_component_update_copy::<C>),
+                component_update_deserialize: Some(vtable_component_update_deserialize::<C>),
+                component_update_serialize: Some(vtable_component_update_serialize::<C>),
+            },
         }
-    }
-}
-
-// Vtable implementation functions.
-pub fn create_component_vtable<C: Component>() -> Worker_ComponentVtable {
-    Worker_ComponentVtable {
-        component_id: C::ID,
-        user_data: ptr::null_mut(),
-        command_request_free: Some(vtable_command_request_free::<C>),
-        command_request_copy: Some(vtable_command_request_copy::<C>),
-        command_request_deserialize: Some(vtable_command_request_deserialize::<C>),
-        command_request_serialize: Some(vtable_command_request_serialize::<C>),
-        command_response_free: Some(vtable_command_response_free::<C>),
-        command_response_copy: Some(vtable_command_response_copy::<C>),
-        command_response_deserialize: Some(vtable_command_response_deserialize::<C>),
-        command_response_serialize: Some(vtable_command_response_serialize::<C>),
-        component_data_free: Some(vtable_component_data_free::<C>),
-        component_data_copy: Some(vtable_component_data_copy::<C>),
-        component_data_deserialize: Some(vtable_component_data_deserialize::<C>),
-        component_data_serialize: Some(vtable_component_data_serialize::<C>),
-        component_update_free: Some(vtable_component_update_free::<C>),
-        component_update_copy: Some(vtable_component_update_copy::<C>),
-        component_update_deserialize: Some(vtable_component_update_deserialize::<C>),
-        component_update_serialize: Some(vtable_component_update_serialize::<C>),
     }
 }
 

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -4,6 +4,8 @@ use std::os::raw;
 use std::sync::Arc;
 use std::{mem, ptr};
 
+pub use inventory;
+
 pub type ComponentId = u32;
 
 pub trait ComponentUpdate<C: Component> {

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -233,7 +233,7 @@ inventory::collect!(VTable);
 // A data structure which represents all known component types. Used to generate an array of vtables to pass
 // to the connection object.
 #[derive(Default)]
-pub struct ComponentDatabase {
+pub(crate) struct ComponentDatabase {
     component_vtables: Vec<Worker_ComponentVtable>,
 }
 

--- a/spatialos-sdk/src/worker/parameters.rs
+++ b/spatialos-sdk/src/worker/parameters.rs
@@ -104,15 +104,15 @@ impl ConnectionParameters {
             thread_affinity: self.thread_affinity.to_worker_sdk(),
             component_vtable_count: match self.components {
                 Some(ref components) => components.len() as u32,
-                None => 0
+                None => 0,
             },
             component_vtables: match self.components {
                 Some(ref components) => components.to_worker_sdk(),
-                None => ptr::null()
+                None => ptr::null(),
             },
             default_component_vtable: match self.components {
                 Some(_) => ptr::null(),
-                None => &vtable::PASSTHROUGH_VTABLE
+                None => &vtable::PASSTHROUGH_VTABLE,
             },
         }
     }

--- a/spatialos-sdk/src/worker/parameters.rs
+++ b/spatialos-sdk/src/worker/parameters.rs
@@ -70,7 +70,7 @@ impl ConnectionParameters {
         self
     }
 
-    pub fn generate_component_vtable(mut self) -> Self {
+    pub fn enable_internal_serialization(mut self) -> Self {
         self.components = Some(ComponentDatabase::new());
         self
     }


### PR DESCRIPTION
This PR introduces the use of the inventory crate for automatic component registration. 

- Added `WrappedVTable` as you must own the type that you call `inventory::collect!()` on. 
	- Could look into whether a typedef is sufficient for this.
- Driveby fix on the worker configs (FPL changes) 

Fixes #57 
Fixes #71 (most of the work appeared to have been done for this..?) 