### PR TITLE
Add Entity Builder

### DIFF
--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -62,8 +62,7 @@ fn logic_loop(c: &mut WorkerConnection) {
             "rusty",
         )
         .set_metadata("Rotator", "rusty")
-        .set_read_access(&["rusty"])
-        .set_write_access(EntityAcl::ID, "rusty")
+        .set_entity_acl_write_access("rusty")
         .build()
         .unwrap();
 

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -50,21 +50,22 @@ fn logic_loop(c: &mut WorkerConnection) {
     // authority over, so that we know which ones we need to be updating.
     let mut world = HashMap::new();
 
-    let entity = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
-        .add_component(
-            example::Rotate {
-                angle: rng.gen_range(0.0, 2.0 * f64::consts::PI),
-                radius: rng.gen_range(20.0, 100.0),
-                center_x: rng.gen_range(-50.0, 50.0),
-                center_y: 0.0,
-                center_z: rng.gen_range(-50.0, 50.0),
-            },
-            "rusty",
-        )
-        .set_metadata("Rotator", "rusty")
-        .set_entity_acl_write_access("rusty")
-        .build()
-        .unwrap();
+    let mut builder = EntityBuilder::new(0.0, 0.0, 0.0, "rusty");
+
+    builder.add_component(
+        example::Rotate {
+            angle: rng.gen_range(0.0, 2.0 * f64::consts::PI),
+            radius: rng.gen_range(20.0, 100.0),
+            center_x: rng.gen_range(-50.0, 50.0),
+            center_y: 0.0,
+            center_z: rng.gen_range(-50.0, 50.0),
+        },
+        "rusty",
+    );
+    builder.set_metadata("Rotator", "rusty");
+    builder.set_entity_acl_write_access("rusty");
+
+    let entity = builder.build().unwrap();
 
     let create_request_id = c.send_create_entity_request(entity, None, None);
     println!("Create entity request ID: {:?}", create_request_id);

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -1,3 +1,4 @@
+use crate::generated::improbable::EntityAcl;
 use crate::{connection_handler::*, opt::*};
 use generated::{example, improbable};
 use rand::Rng;
@@ -11,12 +12,8 @@ use spatialos_sdk::worker::{
     query::{EntityQuery, QueryConstraint, ResultType},
     {EntityId, InterestOverride, LogLevel},
 };
-use std::{
-    collections::HashMap,
-    f64,
-};
+use std::{collections::HashMap, f64};
 use structopt::StructOpt;
-use crate::generated::improbable::EntityAcl;
 
 mod connection_handler;
 #[rustfmt::skip]
@@ -54,19 +51,26 @@ fn logic_loop(c: &mut WorkerConnection) {
     let mut world = HashMap::new();
 
     let entity = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
-        .add_component(example::Rotate {
-            angle: rng.gen_range(0.0, 2.0 * f64::consts::PI),
-            radius: rng.gen_range(20.0, 100.0),
-            center_x: rng.gen_range(-50.0, 50.0),
-            center_y: 0.0,
-            center_z: rng.gen_range(-50.0, 50.0),
-        }, "rusty")
-        .add_component(improbable::Metadata {
-            entity_type: "Rotator".to_owned()
-        }, "rusty")
+        .add_component(
+            example::Rotate {
+                angle: rng.gen_range(0.0, 2.0 * f64::consts::PI),
+                radius: rng.gen_range(20.0, 100.0),
+                center_x: rng.gen_range(-50.0, 50.0),
+                center_y: 0.0,
+                center_z: rng.gen_range(-50.0, 50.0),
+            },
+            "rusty",
+        )
+        .add_component(
+            improbable::Metadata {
+                entity_type: "Rotator".to_owned(),
+            },
+            "rusty",
+        )
         .set_read_access(&["rusty"])
         .set_write_access(EntityAcl::ID, "rusty")
-        .build().unwrap();
+        .build()
+        .unwrap();
 
     let create_request_id = c.send_create_entity_request(entity, None, None);
     println!("Create entity request ID: {:?}", create_request_id);

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -1,4 +1,3 @@
-use crate::generated::improbable::EntityAcl;
 use crate::{connection_handler::*, opt::*};
 use generated::{example, improbable};
 use rand::Rng;

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -61,12 +61,7 @@ fn logic_loop(c: &mut WorkerConnection) {
             },
             "rusty",
         )
-        .add_component(
-            improbable::Metadata {
-                entity_type: "Rotator".to_owned(),
-            },
-            "rusty",
-        )
+        .set_metadata("Rotator", "rusty")
         .set_read_access(&["rusty"])
         .set_write_access(EntityAcl::ID, "rusty")
         .build()

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -28,7 +28,7 @@ impl Entity {
         Ok(entity)
     }
 
-    pub fn add<C: Component>(&mut self, component: C) -> Result<(), String> {
+    pub(crate) fn add<C: Component>(&mut self, component: C) -> Result<(), String> {
         self.pre_add_check(C::ID)?;
 
         let data_ptr = component::handle_allocate(component);

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -76,7 +76,7 @@ impl Entity {
         &mut self,
         component: SchemaComponentData,
     ) -> Result<(), String> {
-        let vtable = self.database.get_vtable(component.component_id).unwrap();
+        let vtable = DATABASE.get_vtable(component.component_id).unwrap();
         let deserialize_func = vtable.component_data_deserialize.unwrap_or_else(|| {
             Schema_DestroyComponentData(component.internal);
             panic!(

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -97,7 +97,7 @@ impl Entity {
             reserved: ptr::null_mut(),
             component_id: component.component_id,
             schema_type: ptr::null_mut(),
-            user_handle: deserialized_data_ptr
+            user_handle: *handle_out_ptr
         };
 
         self.add_raw(&component_data)

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -30,7 +30,9 @@ impl EntityBuilder {
             error: None,
         };
 
-        builder.write_permissions.insert(POSITION_COMPONENT_ID, position_write_layer.into());
+        builder
+            .write_permissions
+            .insert(POSITION_COMPONENT_ID, position_write_layer.into());
 
         builder
     }
@@ -69,6 +71,15 @@ impl EntityBuilder {
         Ok(self.entity)
     }
 
+    // A workaround for not having access to generated code types here. The shape of Position
+    // & EntityAcl are well known, so we can manually serialize them and pass them into the
+    // Entity in SchemaComponentData form.
+    //
+    // This does then expect that there is a valid deserialize method defined for both components
+    // in the vtable.
+    //
+    // If this invariant is broken, then the EntityBuilder is broken. Should we assert against this
+    // before we call `entity.add_serialized`?
     fn serialize_position(&self) -> SchemaComponentData {
         let mut position_schema = SchemaComponentData::new(POSITION_COMPONENT_ID);
         let position_fields = position_schema.fields_mut();

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -24,7 +24,7 @@ pub struct EntityBuilder {
     write_permissions: HashMap<ComponentId, String>,
     read_permissions: Vec<String>,
 
-    error: Option<String>
+    error: Option<String>,
 }
 
 impl EntityBuilder {
@@ -56,7 +56,11 @@ impl EntityBuilder {
         self.set_write_access(PERSISTENCE_COMPONENT_ID, write_layer)
     }
 
-    pub fn set_metadata<T: Into<String>, U: Into<String>>(mut self, entity_type: T, write_layer: U) -> Self {
+    pub fn set_metadata<T: Into<String>, U: Into<String>>(
+        mut self,
+        entity_type: T,
+        write_layer: U,
+    ) -> Self {
         self.metadata = Some(entity_type.into());
         self.set_write_access(METADATA_COMPONENT_ID, write_layer)
     }
@@ -144,7 +148,9 @@ impl EntityBuilder {
     fn serialize_metadata(&self) -> SchemaComponentData {
         let mut metadata_schema = SchemaComponentData::new(METADATA_COMPONENT_ID);
         let metadata_fields = metadata_schema.fields_mut();
-        metadata_fields.field::<SchemaString>(1).add(self.metadata.as_ref().unwrap());
+        metadata_fields
+            .field::<SchemaString>(1)
+            .add(self.metadata.as_ref().unwrap());
 
         metadata_schema
     }

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -71,9 +71,9 @@ impl EntityBuilder {
 
     fn serialize_position(&self) -> SchemaComponentData {
         let mut position_schema = SchemaComponentData::new(POSITION_COMPONENT_ID);
-        let mut position_fields = position_schema.fields_mut();
+        let position_fields = position_schema.fields_mut();
 
-        let mut coords_obj = position_fields.field::<SchemaObject>(1).add();
+        let coords_obj = position_fields.field::<SchemaObject>(1).add();
         coords_obj.field::<SchemaDouble>(1).add(self.position.0);
         coords_obj.field::<SchemaDouble>(2).add(self.position.1);
         coords_obj.field::<SchemaDouble>(3).add(self.position.2);
@@ -83,11 +83,11 @@ impl EntityBuilder {
 
     fn serialize_acl(&self) -> SchemaComponentData {
         let mut acl_schema = SchemaComponentData::new(ENTITY_ACL_COMPONENT_ID);
-        let mut acl_fields = acl_schema.fields_mut();
+        let acl_fields = acl_schema.fields_mut();
 
-        let mut read_access = acl_fields.field::<SchemaObject>(1).add();
+        let read_access = acl_fields.field::<SchemaObject>(1).add();
         for layer in &self.read_permissions {
-            let mut attribute_set = read_access.field::<SchemaObject>(1).add();
+            let attribute_set = read_access.field::<SchemaObject>(1).add();
             attribute_set.field::<SchemaString>(1).add(layer);
         }
 

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -21,14 +21,18 @@ pub struct EntityBuilder {
 }
 
 impl EntityBuilder {
-    pub fn new(x: f64, y: f64, z: f64) -> Self {
-        EntityBuilder {
+    pub fn new<T: Into<String>>(x: f64, y: f64, z: f64, position_write_layer: T) -> Self {
+        let mut builder = EntityBuilder {
             position: (x, y, z),
             entity: Entity::new(),
             write_permissions: HashMap::new(),
             read_permissions: Vec::new(),
             error: None,
-        }
+        };
+
+        builder.write_permissions.insert(POSITION_COMPONENT_ID, position_write_layer.into());
+
+        builder
     }
 
     pub fn add_component<C: Component, T: Into<String>>(mut self, data: C, write_layer: T) -> Self {
@@ -46,6 +50,11 @@ impl EntityBuilder {
             .map(|layer| layer.as_ref().to_owned())
             .collect();
 
+        self
+    }
+
+    pub fn set_write_access<T: Into<String>>(mut self, id: ComponentId, layer: T) -> Self {
+        self.write_permissions.insert(id, layer.into());
         self
     }
 
@@ -88,6 +97,8 @@ impl EntityBuilder {
 
             map_obj
                 .field::<SchemaObject>(2)
+                .add()
+                .field::<SchemaObject>(1)
                 .add()
                 .field::<SchemaString>(1)
                 .add(pair.1);

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -43,43 +43,39 @@ impl EntityBuilder {
         builder
     }
 
-    pub fn add_component<C: Component, T: Into<String>>(mut self, data: C, write_layer: T) -> Self {
+    pub fn add_component<C: Component, T: Into<String>>(&mut self, data: C, write_layer: T) {
         if let Err(e) = self.entity.add(data) {
             self.error = Some(e);
         };
 
         self.add_write_access(C::ID, write_layer);
-        self
     }
 
-    pub fn set_persistent<T: Into<String>>(mut self, write_layer: T) -> Self {
+    pub fn set_persistent<T: Into<String>>(&mut self, write_layer: T) {
         self.is_persistent = true;
         self.add_write_access(PERSISTENCE_COMPONENT_ID, write_layer);
-        self
     }
 
     pub fn set_metadata<T: Into<String>, U: Into<String>>(
-        mut self,
+        &mut self,
         entity_type: T,
         write_layer: U,
-    ) -> Self {
+    ) {
         self.metadata = Some(entity_type.into());
         self.add_write_access(METADATA_COMPONENT_ID, write_layer);
-        self
     }
 
-    pub fn add_read_access<T: Into<String>>(mut self, layer: T) -> Self {
+    pub fn add_read_access<T: Into<String>>(&mut self, layer: T) {
         self.read_permissions.insert(layer.into());
-        self
     }
 
-    pub fn set_entity_acl_write_access<T: Into<String>>(mut self, layer: T) -> Self {
+    pub fn set_entity_acl_write_access<T: Into<String>>(&mut self, layer: T) {
         self.add_write_access(ENTITY_ACL_COMPONENT_ID, layer);
-        self
     }
 
     fn add_write_access<T: Into<String>>(&mut self, id: ComponentId, layer: T) {
-        self.write_permissions.insert(ENTITY_ACL_COMPONENT_ID, layer.into());
+        self.write_permissions
+            .insert(ENTITY_ACL_COMPONENT_ID, layer.into());
         self.read_permissions.insert(layer.into());
     }
 

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -35,7 +35,7 @@ impl EntityBuilder {
             metadata: None,
             position: (x, y, z),
             write_permissions: HashMap::new(),
-            read_permissions: Vec::new(),
+            read_permissions: HashSet::new(),
             error: None,
         };
 
@@ -74,9 +74,9 @@ impl EntityBuilder {
     }
 
     fn add_write_access<T: Into<String>>(&mut self, id: ComponentId, layer: T) {
-        self.write_permissions
-            .insert(ENTITY_ACL_COMPONENT_ID, layer.into());
-        self.read_permissions.insert(layer.into());
+        let layer = layer.into();
+        self.write_permissions.insert(id, layer.clone());
+        self.read_permissions.insert(layer);
     }
 
     pub fn build(mut self) -> Result<Entity, String> {

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -1,0 +1,98 @@
+use crate::worker::{
+    component::Component,
+    component::ComponentId,
+    entity::Entity,
+    internal::schema::{
+        SchemaComponentData, SchemaDouble, SchemaObject, SchemaObjectField, SchemaPrimitiveField,
+        SchemaString, SchemaStringField, SchemaUint32,
+    },
+};
+use std::collections::HashMap;
+
+const POSITION_COMPONENT_ID: ComponentId = 54;
+const ENTITY_ACL_COMPONENT_ID: ComponentId = 50;
+
+pub struct EntityBuilder {
+    position: (f64, f64, f64),
+    entity: Entity,
+    write_permissions: HashMap<ComponentId, String>,
+    read_permissions: Vec<String>,
+    error: Option<String>,
+}
+
+impl EntityBuilder {
+    pub fn new(x: f64, y: f64, z: f64) -> Self {
+        EntityBuilder {
+            position: (x, y, z),
+            entity: Entity::new(),
+            write_permissions: HashMap::new(),
+            read_permissions: Vec::new(),
+            error: None,
+        }
+    }
+
+    pub fn add_component<C: Component, T: Into<String>>(mut self, data: C, write_layer: T) -> Self {
+        if let Err(e) = self.entity.add(data) {
+            self.error = Some(e);
+        };
+
+        self.write_permissions.insert(C::ID, write_layer.into());
+        self
+    }
+
+    pub fn set_read_access<T: AsRef<str>>(mut self, layers: &[T]) -> Self {
+        self.read_permissions = layers
+            .iter()
+            .map(|layer| layer.as_ref().to_owned())
+            .collect();
+
+        self
+    }
+
+    pub fn build(mut self) -> Result<Entity, String> {
+        if let Some(e) = self.error {
+            return Err(e);
+        }
+
+        unsafe { self.entity.add_serialized(self.serialize_position())? };
+        unsafe { self.entity.add_serialized(self.serialize_acl())? }
+
+        Ok(self.entity)
+    }
+
+    fn serialize_position(&self) -> SchemaComponentData {
+        let mut position_schema = SchemaComponentData::new(POSITION_COMPONENT_ID);
+        let mut position_fields = position_schema.fields_mut();
+
+        let mut coords_obj = position_fields.field::<SchemaObject>(1).add();
+        coords_obj.field::<SchemaDouble>(1).add(self.position.0);
+        coords_obj.field::<SchemaDouble>(2).add(self.position.1);
+        coords_obj.field::<SchemaDouble>(3).add(self.position.2);
+
+        position_schema
+    }
+
+    fn serialize_acl(&self) -> SchemaComponentData {
+        let mut acl_schema = SchemaComponentData::new(ENTITY_ACL_COMPONENT_ID);
+        let mut acl_fields = acl_schema.fields_mut();
+
+        let mut read_access = acl_fields.field::<SchemaObject>(1).add();
+        for layer in &self.read_permissions {
+            let mut attribute_set = read_access.field::<SchemaObject>(1).add();
+            attribute_set.field::<SchemaString>(1).add(layer);
+        }
+
+        for pair in &self.write_permissions {
+            let map_obj = acl_fields.field::<SchemaObject>(2).add();
+            map_obj.field::<SchemaUint32>(1).add(*pair.0);
+
+            map_obj
+                .field::<SchemaObject>(2)
+                .add()
+                .field::<SchemaString>(1)
+                .add(pair.1);
+        }
+
+        acl_schema
+    }
+}

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod component;
 pub mod connection;
 pub mod entity;
+pub mod entity_builder;
 pub mod locator;
 pub mod metrics;
 pub mod op;

--- a/test-suite/src/entity_builder_tests.rs
+++ b/test-suite/src/entity_builder_tests.rs
@@ -1,0 +1,72 @@
+use approx;
+use spatialos_sdk::worker::component::Component;
+use spatialos_sdk::worker::entity_builder::EntityBuilder;
+use crate::generated::improbable::*;
+
+#[test]
+fn position_is_serialized_correctly() {
+    let entity = EntityBuilder::new(10.0, -10.0, 7.5, "rusty")
+        .build()
+        .unwrap();
+
+    let maybe_position = entity.get::<Position>();
+    assert!(maybe_position.is_some());
+
+    let position = maybe_position.unwrap();
+
+    approx::abs_diff_eq!(10.0, position.coords.x);
+    approx::abs_diff_eq!(-10.0, position.coords.y);
+    approx::abs_diff_eq!(7.5, position.coords.z);
+}
+
+#[test]
+fn entity_acl_is_serialized_correctly() {
+    let entity = EntityBuilder::new(0.0, 0.0, 0.0, "position_acl")
+        .add_component(Metadata {
+            entity_type: "test".to_owned()
+        }, "metadata_acl")
+        .set_write_access(EntityAcl::ID, "entity_acl_acl")
+        .set_read_access(&["client", "server"])
+        .build().unwrap();
+
+    let maybe_acl = entity.get::<EntityAcl>();
+    assert!(maybe_acl.is_some());
+
+    let acl = maybe_acl.unwrap();
+
+    // First check that we insert each layer into a different set.
+    assert_eq!(2, acl.read_acl.attribute_set.len());
+
+    let read_acl_layers: Vec<String> = acl.read_acl.attribute_set
+        .iter()
+        .flat_map(|requirement_set| {
+            requirement_set.attribute.clone()
+        })
+        .collect();
+
+    // Then check that both layers exist in the combined set.
+    assert!(read_acl_layers.contains(&"client".to_owned()));
+    assert!(read_acl_layers.contains(&"server".to_owned()));
+
+    // Test that position is correctly inserted.
+    let maybe_position_acl = acl.component_write_acl.get(&Position::ID);
+    assert!(maybe_position_acl.is_some());
+    let position_acl = maybe_position_acl.unwrap();
+    assert_eq!(1, position_acl.attribute_set.len());
+    assert!(position_acl.attribute_set[0].attribute.contains(&"position_acl".to_owned()));
+
+    // Test that arbitrary components are correctly inserted.
+    let maybe_metadata_acl = acl.component_write_acl.get(&Metadata::ID);
+    assert!(maybe_metadata_acl.is_some());
+    let metadata_acl = maybe_metadata_acl.unwrap();
+    assert_eq!(1, metadata_acl.attribute_set.len());
+    assert!(metadata_acl.attribute_set[0].attribute.contains(&"metadata_acl".to_owned()));
+
+    // Test that set write access is correctly inserted.
+    let maybe_entity_acl_acl = acl.component_write_acl.get(&EntityAcl::ID);
+    assert!(maybe_entity_acl_acl.is_some());
+    let entity_acl_acl = maybe_entity_acl_acl.unwrap();
+    assert_eq!(1, entity_acl_acl.attribute_set.len());
+    assert!(entity_acl_acl.attribute_set[0].attribute.contains(&"entity_acl_acl".to_owned()));
+
+}

--- a/test-suite/src/entity_builder_tests.rs
+++ b/test-suite/src/entity_builder_tests.rs
@@ -48,6 +48,9 @@ fn entity_acl_is_serialized_correctly() {
     assert!(read_acl_layers.contains(&"client".to_owned()));
     assert!(read_acl_layers.contains(&"server".to_owned()));
 
+    // Check that the correct number of write ACL exists.
+    assert_eq!(3, acl.component_write_acl.len());
+
     // Test that position is correctly inserted.
     let maybe_position_acl = acl.component_write_acl.get(&Position::ID);
     assert!(maybe_position_acl.is_some());
@@ -69,4 +72,13 @@ fn entity_acl_is_serialized_correctly() {
     assert_eq!(1, entity_acl_acl.attribute_set.len());
     assert!(entity_acl_acl.attribute_set[0].attribute.contains(&"entity_acl_acl".to_owned()));
 
+}
+
+#[test]
+fn error_is_returned_if_invalid_entity() {
+    let result = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
+        .add_component(Position { coords: Coordinates { x: 0.0, y: 0.0, z: 0.0 }}, "rusty")
+        .build();
+
+    assert!(result.is_err());
 }

--- a/test-suite/src/entity_builder_tests.rs
+++ b/test-suite/src/entity_builder_tests.rs
@@ -83,6 +83,31 @@ fn entity_acl_is_serialized_correctly() {
         .contains(&"entity_acl_acl".to_owned()));
 }
 
+
+#[test]
+fn metadata_is_serialized_correctly() {
+    let entity = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
+        .set_metadata("my_entity", "rusty")
+        .build()
+        .unwrap();
+
+    let maybe_metadata = entity.get::<Metadata>();
+    assert!(maybe_metadata.is_some());
+    let metadata = maybe_metadata.unwrap();
+
+    assert_eq!("my_entity", metadata.entity_type);
+}
+
+#[test]
+fn persistence_component_is_added_if_set() {
+    let entity = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
+        .set_persistent("rusty")
+        .build()
+        .unwrap();
+
+    assert!(entity.get::<Persistence>().is_some());
+}
+
 #[test]
 fn error_is_returned_if_invalid_entity() {
     let result = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")

--- a/test-suite/src/entity_builder_tests.rs
+++ b/test-suite/src/entity_builder_tests.rs
@@ -1,7 +1,7 @@
+use crate::generated::improbable::*;
 use approx;
 use spatialos_sdk::worker::component::Component;
 use spatialos_sdk::worker::entity_builder::EntityBuilder;
-use crate::generated::improbable::*;
 
 #[test]
 fn position_is_serialized_correctly() {
@@ -22,12 +22,16 @@ fn position_is_serialized_correctly() {
 #[test]
 fn entity_acl_is_serialized_correctly() {
     let entity = EntityBuilder::new(0.0, 0.0, 0.0, "position_acl")
-        .add_component(Metadata {
-            entity_type: "test".to_owned()
-        }, "metadata_acl")
+        .add_component(
+            Metadata {
+                entity_type: "test".to_owned(),
+            },
+            "metadata_acl",
+        )
         .set_write_access(EntityAcl::ID, "entity_acl_acl")
         .set_read_access(&["client", "server"])
-        .build().unwrap();
+        .build()
+        .unwrap();
 
     let maybe_acl = entity.get::<EntityAcl>();
     assert!(maybe_acl.is_some());
@@ -37,11 +41,11 @@ fn entity_acl_is_serialized_correctly() {
     // First check that we insert each layer into a different set.
     assert_eq!(2, acl.read_acl.attribute_set.len());
 
-    let read_acl_layers: Vec<String> = acl.read_acl.attribute_set
+    let read_acl_layers: Vec<String> = acl
+        .read_acl
+        .attribute_set
         .iter()
-        .flat_map(|requirement_set| {
-            requirement_set.attribute.clone()
-        })
+        .flat_map(|requirement_set| requirement_set.attribute.clone())
         .collect();
 
     // Then check that both layers exist in the combined set.
@@ -56,28 +60,42 @@ fn entity_acl_is_serialized_correctly() {
     assert!(maybe_position_acl.is_some());
     let position_acl = maybe_position_acl.unwrap();
     assert_eq!(1, position_acl.attribute_set.len());
-    assert!(position_acl.attribute_set[0].attribute.contains(&"position_acl".to_owned()));
+    assert!(position_acl.attribute_set[0]
+        .attribute
+        .contains(&"position_acl".to_owned()));
 
     // Test that arbitrary components are correctly inserted.
     let maybe_metadata_acl = acl.component_write_acl.get(&Metadata::ID);
     assert!(maybe_metadata_acl.is_some());
     let metadata_acl = maybe_metadata_acl.unwrap();
     assert_eq!(1, metadata_acl.attribute_set.len());
-    assert!(metadata_acl.attribute_set[0].attribute.contains(&"metadata_acl".to_owned()));
+    assert!(metadata_acl.attribute_set[0]
+        .attribute
+        .contains(&"metadata_acl".to_owned()));
 
     // Test that set write access is correctly inserted.
     let maybe_entity_acl_acl = acl.component_write_acl.get(&EntityAcl::ID);
     assert!(maybe_entity_acl_acl.is_some());
     let entity_acl_acl = maybe_entity_acl_acl.unwrap();
     assert_eq!(1, entity_acl_acl.attribute_set.len());
-    assert!(entity_acl_acl.attribute_set[0].attribute.contains(&"entity_acl_acl".to_owned()));
-
+    assert!(entity_acl_acl.attribute_set[0]
+        .attribute
+        .contains(&"entity_acl_acl".to_owned()));
 }
 
 #[test]
 fn error_is_returned_if_invalid_entity() {
     let result = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
-        .add_component(Position { coords: Coordinates { x: 0.0, y: 0.0, z: 0.0 }}, "rusty")
+        .add_component(
+            Position {
+                coords: Coordinates {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            },
+            "rusty",
+        )
         .build();
 
     assert!(result.is_err());

--- a/test-suite/src/entity_builder_tests.rs
+++ b/test-suite/src/entity_builder_tests.rs
@@ -83,7 +83,6 @@ fn entity_acl_is_serialized_correctly() {
         .contains(&"entity_acl_acl".to_owned()));
 }
 
-
 #[test]
 fn metadata_is_serialized_correctly() {
     let entity = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")

--- a/test-suite/src/entity_builder_tests.rs
+++ b/test-suite/src/entity_builder_tests.rs
@@ -5,9 +5,8 @@ use spatialos_sdk::worker::entity_builder::EntityBuilder;
 
 #[test]
 fn position_is_serialized_correctly() {
-    let entity = EntityBuilder::new(10.0, -10.0, 7.5, "rusty")
-        .build()
-        .unwrap();
+    let builder = EntityBuilder::new(10.0, -10.0, 7.5, "rusty");
+    let entity = builder.build().unwrap();
 
     let maybe_position = entity.get::<Position>();
     assert!(maybe_position.is_some());
@@ -21,17 +20,18 @@ fn position_is_serialized_correctly() {
 
 #[test]
 fn entity_acl_is_serialized_correctly() {
-    let entity = EntityBuilder::new(0.0, 0.0, 0.0, "position_acl")
-        .add_component(
-            Metadata {
-                entity_type: "test".to_owned(),
-            },
-            "metadata_acl",
-        )
-        .set_entity_acl_write_access(EntityAcl::ID, "entity_acl_acl")
-        .add_read_access(&["client", "server"])
-        .build()
-        .unwrap();
+    let mut builder = EntityBuilder::new(0.0, 0.0, 0.0, "position_acl");
+    builder.add_component(
+        Metadata {
+            entity_type: "test".to_owned(),
+        },
+        "metadata_acl",
+    );
+    builder.set_entity_acl_write_access("entity_acl_acl");
+    builder.add_read_access("client");
+    builder.add_read_access("server");
+
+    let entity = builder.build().unwrap();
 
     let maybe_acl = entity.get::<EntityAcl>();
     assert!(maybe_acl.is_some());
@@ -39,7 +39,7 @@ fn entity_acl_is_serialized_correctly() {
     let acl = maybe_acl.unwrap();
 
     // First check that we insert each layer into a different set.
-    assert_eq!(2, acl.read_acl.attribute_set.len());
+    assert_eq!(5, acl.read_acl.attribute_set.len());
 
     let read_acl_layers: Vec<String> = acl
         .read_acl
@@ -85,10 +85,9 @@ fn entity_acl_is_serialized_correctly() {
 
 #[test]
 fn metadata_is_serialized_correctly() {
-    let entity = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
-        .set_metadata("my_entity", "rusty")
-        .build()
-        .unwrap();
+    let mut builder = EntityBuilder::new(0.0, 0.0, 0.0, "rusty");
+    builder.set_metadata("my_entity", "rusty");
+    let entity = builder.build().unwrap();
 
     let maybe_metadata = entity.get::<Metadata>();
     assert!(maybe_metadata.is_some());
@@ -99,28 +98,27 @@ fn metadata_is_serialized_correctly() {
 
 #[test]
 fn persistence_component_is_added_if_set() {
-    let entity = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
-        .set_persistent("rusty")
-        .build()
-        .unwrap();
+    let mut builder = EntityBuilder::new(0.0, 0.0, 0.0, "rusty");
+    builder.set_persistent("rusty");
+    let entity = builder.build().unwrap();
 
     assert!(entity.get::<Persistence>().is_some());
 }
 
 #[test]
 fn error_is_returned_if_invalid_entity() {
-    let result = EntityBuilder::new(0.0, 0.0, 0.0, "rusty")
-        .add_component(
-            Position {
-                coords: Coordinates {
-                    x: 0.0,
-                    y: 0.0,
-                    z: 0.0,
-                },
+    let mut builder = EntityBuilder::new(0.0, 0.0, 0.0, "rusty");
+    builder.add_component(
+        Position {
+            coords: Coordinates {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
             },
-            "rusty",
-        )
-        .build();
+        },
+        "rusty",
+    );
+    let result = builder.build();
 
     assert!(result.is_err());
 }

--- a/test-suite/src/entity_builder_tests.rs
+++ b/test-suite/src/entity_builder_tests.rs
@@ -28,8 +28,8 @@ fn entity_acl_is_serialized_correctly() {
             },
             "metadata_acl",
         )
-        .set_write_access(EntityAcl::ID, "entity_acl_acl")
-        .set_read_access(&["client", "server"])
+        .set_entity_acl_write_access(EntityAcl::ID, "entity_acl_acl")
+        .add_read_access(&["client", "server"])
         .build()
         .unwrap();
 

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -2,6 +2,6 @@
 pub mod generated;
 
 #[cfg(test)]
-pub mod snapshot_integration_tests;
-#[cfg(test)]
 pub mod entity_builder_tests;
+#[cfg(test)]
+pub mod snapshot_integration_tests;

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -3,4 +3,5 @@ pub mod generated;
 
 #[cfg(test)]
 pub mod snapshot_integration_tests;
+#[cfg(test)]
 pub mod entity_builder_tests;

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -3,3 +3,4 @@ pub mod generated;
 
 #[cfg(test)]
 pub mod snapshot_integration_tests;
+pub mod entity_builder_tests;

--- a/test-suite/src/snapshot_integration_tests.rs
+++ b/test-suite/src/snapshot_integration_tests.rs
@@ -1,8 +1,9 @@
 use approx;
 use spatialos_sdk::worker::{entity::Entity, snapshot::*, EntityId};
-use std::{collections::BTreeMap, env};
+use std::env;
 
 use crate::generated::improbable::*;
+use spatialos_sdk::worker::entity_builder::EntityBuilder;
 
 #[test]
 pub fn writing_invalid_entity_returns_error() {
@@ -56,28 +57,7 @@ pub fn create_and_read_snapshot() {
 }
 
 fn get_test_entity() -> Result<Entity, String> {
-    let mut entity = Entity::new();
-
-    let position = Position {
-        coords: Coordinates {
-            x: 10.0,
-            y: -10.0,
-            z: 0.0,
-        },
-    };
-
-    let acl = EntityAcl {
-        read_acl: WorkerRequirementSet {
-            attribute_set: vec![WorkerAttributeSet {
-                attribute: vec!["RustWorker".to_owned()],
-            }],
-        },
-        component_write_acl: BTreeMap::new(),
-    };
-
-    entity.add(position)?;
-    entity.add(acl)?;
-    entity.add(Persistence {})?;
-
-    Ok(entity)
+    let mut builder = EntityBuilder::new(10.0, -10.0, 0.0, "RustWorker");
+    builder.set_persistent("RustWorker");
+    builder.build()
 }


### PR DESCRIPTION
This PR introduces an `EntityBuilder` which helps users create entities and cuts down the verbosity required to do so.

It includes: 
- Forcing a user to provide a position (required component).
- Automatic building of the `EntityACL` component (required component).
- Making users specify a write-access layer when adding a component.
- Providing special methods for other well-known components (Metadata and Persistence).

These four features makes it much less error-prone when creating entities. However, there is still one place to trip up on:

- Setting read layers is still done in a separate method. This is easy to mess up (by omission). We could make this part of the EntityBuilder constructor to force users to pass this in, but the constructor will start to get very long.

Note that there is a little bit of hackery in the implementation as we need to "access" code generated types (Position, EntityAcl, Metadata, EntityAcl) but do not have the generated code available at compile time. To get around this, we manually serialize the data (since its a well known shape) then deserialize inside the `Entity` itself. (At runtime we do expect to have these types defined). Do we expect the `add_serialized` method on `Entity` to be used elsewhere? Or can it be folded into the `EntityBuilder` as an implementation detail? 

Fixes #25 