### PR TITLE
Make ReserveEntityIdsResponse contain an iterator

### DIFF
--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -7,7 +7,7 @@ use spatialos_sdk::worker::{
     connection::{Connection, WorkerConnection},
     entity::Entity,
     metrics::{HistogramMetric, Metrics},
-    op::WorkerOp,
+    op::{StatusCode, WorkerOp},
     query::{EntityQuery, QueryConstraint, ResultType},
     {EntityId, InterestOverride, LogLevel},
 };
@@ -175,7 +175,14 @@ fn logic_loop(c: &mut WorkerConnection) {
                     }
                     id => println!("Received unknown component: {}", id),
                 },
-
+                WorkerOp::ReserveEntityIdsResponse(response) => match response.status_code {
+                    StatusCode::Success(range) => {
+                        for entity_id in range {
+                            println!("Reserved entity id: {:?}", entity_id);
+                        }
+                    }
+                    _ => println!("ReserveEntityIds command request failed."),
+                },
                 _ => {}
             }
         }

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -647,3 +647,25 @@ impl<'a> CommandResponse<'a> {
         &self.response.schema_type
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::ReservedEntityIdRange;
+
+    #[test]
+    fn reserved_entity_id_range_iterator_contains_correct_count() {
+        let range = ReservedEntityIdRange::new(10, 54);
+        assert_eq!(54, range.count());
+    }
+
+    #[test]
+    fn reserved_entity_id_range_iterator_returns_sequential_ids() {
+        let mut current_id :i64 = 1;
+        let range = ReservedEntityIdRange::new(current_id, 10);
+
+        for entity_id in range {
+            assert_eq!(current_id, entity_id.id);
+            current_id += 1;
+        }
+    }
+}

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -660,7 +660,7 @@ mod test {
 
     #[test]
     fn reserved_entity_id_range_iterator_returns_sequential_ids() {
-        let mut current_id :i64 = 1;
+        let mut current_id: i64 = 1;
         let range = ReservedEntityIdRange::new(current_id, 10);
 
         for entity_id in range {

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -477,6 +477,8 @@ pub struct ReserveEntityIdsResponseOp {
     pub status_code: StatusCode<ReservedEntityIdRange>,
 }
 
+// TODO: When https://doc.rust-lang.org/std/iter/trait.Step.html is stabilized - replace this
+//       with std::ops::Range<EntityId> and implement Step for EntityId.
 #[derive(Debug)]
 pub struct ReservedEntityIdRange {
     current: i64,


### PR DESCRIPTION
Reworked the `ReservedEntityIdsRange` to be an iterator and hid the internals. 

Fixes #65 

