### PR TITLE
Fix memory leak

### DIFF
--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -413,6 +413,10 @@ impl Connection for WorkerConnection {
             )
         };
 
+        unsafe {
+            component::handle_free::<C::CommandRequest>(command_request.user_handle);
+        }
+
         RequestId::new(request_id)
     }
 
@@ -434,6 +438,8 @@ impl Connection for WorkerConnection {
                 request_id.id,
                 &raw_response,
             );
+
+            component::handle_free::<C::CommandResponse>(raw_response.user_handle);
         }
     }
 
@@ -475,6 +481,8 @@ impl Connection for WorkerConnection {
                 &component_update,
                 &params,
             );
+
+            component::handle_free::<C::Update>(component_update.user_handle);
         }
     }
 


### PR DESCRIPTION
Noticed a memory leak when sending updates when implementing a view and tracked it down to this.

TL;DR - the C API will call the vtable copy function, but won't free the original data. We need to free the data after calling the C API function.