### PR TITLE
Entity id codegen bugfix

### DIFF
--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -163,7 +163,7 @@ impl Package {
                 PrimitiveType::Float => "f32",
                 PrimitiveType::Double => "f64",
                 PrimitiveType::String => "String",
-                PrimitiveType::EntityId => "worker::EntityId",
+                PrimitiveType::EntityId => "spatialos_sdk::worker::EntityId",
                 PrimitiveType::Bytes => "Vec<u8>",
             }
             .to_string()


### PR DESCRIPTION
Hit this one as well - the import was slightly wrong for `EntityId` in generated code.