### PR TITLE
Make SnapshotOutputStream::write_entity a mutable borrow

### DIFF
--- a/spatialos-sdk/src/worker/snapshot.rs
+++ b/spatialos-sdk/src/worker/snapshot.rs
@@ -32,7 +32,7 @@ impl SnapshotOutputStream {
         Ok(stream)
     }
 
-    pub fn write_entity(&self, id: EntityId, entity: &Entity) -> Result<(), String> {
+    pub fn write_entity(&mut self, id: EntityId, entity: &Entity) -> Result<(), String> {
         let components = entity.raw_component_data();
 
         let wrk_entity = Worker_Entity {

--- a/test-suite/src/snapshot_integration_tests.rs
+++ b/test-suite/src/snapshot_integration_tests.rs
@@ -25,8 +25,8 @@ pub fn create_and_read_snapshot() {
     let entity = get_test_entity().expect("Error");
 
     {
-        let snapshot = SnapshotOutputStream::new(snapshot_path.clone()).expect("Error");
-        snapshot
+        SnapshotOutputStream::new(snapshot_path.clone())
+            .expect("Error")
             .write_entity(EntityId::new(1), &entity)
             .expect("Error");
     }


### PR DESCRIPTION
Missed this one in the original PR :grimacing: 