### PR TITLE
Add user handle abstraction

### DIFF
--- a/spatialos-sdk/src/lib.rs
+++ b/spatialos-sdk/src/lib.rs
@@ -1,5 +1,8 @@
 extern crate spatialos_sdk_sys;
 
+// TODO: Where should this live? We only need it for tests in order to reduce
+// boilerplate, but it needs to live in the crate because we use it for both
+// internal and external tests.
 #[macro_export]
 macro_rules! dummy_component {
     ($component:ident, $update:ident) => {

--- a/spatialos-sdk/src/lib.rs
+++ b/spatialos-sdk/src/lib.rs
@@ -1,4 +1,34 @@
 extern crate spatialos_sdk_sys;
 
+#[macro_export]
+macro_rules! dummy_component {
+    ($component:ident, $update:ident) => {
+        impl $crate::worker::schema::SchemaObjectType for $component {
+            fn from_object(_: &$crate::worker::schema::Object) -> Self {
+                unimplemented!()
+            }
+
+            fn into_object(&self, _: &mut $crate::worker::schema::Object) {
+                unimplemented!();
+            }
+        }
+
+        impl $crate::worker::component::Component for $component {
+            const ID: $crate::worker::component::ComponentId = 1234;
+            type Update = $update;
+        }
+
+        inventory::submit!($crate::worker::component::VTable::new::<
+            $component,
+        >());
+
+        pub struct $update;
+
+        impl $crate::worker::component::Update for $update {
+            type Component = $component;
+        }
+    };
+}
+
 pub(crate) mod ptr;
 pub mod worker;

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -68,6 +68,12 @@ impl Entity {
     /// data or user handles. If the raw data is passed to the C API using
     /// `Worker_Connection_SendCreateEntityRequest`, the C API will take ownership of
     /// the data and will free it when it's done.
+    ///
+    /// Additionally, this function returns any user handles that are owned by the
+    /// entity. The returned `Worker_ComponentData` objects borrow data from the user
+    /// handles, and so the user handles must remain in scope until the component data
+    /// has been passed to the C API. At that point, the C API will have had a chance
+    /// to clone the handles, and so it is safe to drop the returned handles.
     pub(crate) fn into_raw(mut self) -> (Vec<Worker_ComponentData>, Vec<UserHandle>) {
         let mut components = Vec::with_capacity(self.components.len());
         let mut handles = Vec::with_capacity(self.components.len());

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -35,7 +35,7 @@ impl EntityBuilder {
         builder
     }
 
-    pub fn add<C: Component, T: Into<String>>(
+    pub fn add<C: Component + Send, T: Into<String>>(
         &mut self,
         data: C,
         write_layer: T,
@@ -57,7 +57,7 @@ impl EntityBuilder {
         Ok(())
     }
 
-    pub fn add_handle<C: Component, T: Into<String>>(
+    pub fn add_handle<C: Component + Send, T: Into<String>>(
         &mut self,
         data: C,
         write_layer: T,

--- a/spatialos-sdk/src/worker/handle.rs
+++ b/spatialos-sdk/src/worker/handle.rs
@@ -1,0 +1,106 @@
+//! A type-erased [`Arc`], used to pass user-defined data types to the C API.
+//!
+//! A common pattern with the C SDK in order to move serialization off the main
+//! thread is to pass a pointer to some user-defined data to the C API, along with
+//! a vtable of serialization functions, and allow the C SDK to perform
+//! serialization automatically. In order to make use of this approach, we need a
+//! type-erased, thread-safe, reference counted pointer type; We need an [`Arc`],
+//! but type-erased.
+//!
+//! [`UserHandle`] provides this functionality, providing a safe way to create
+//! type-erased handles that are automatically freed when dropped.
+//!
+//! [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+//! [`UserHandle`]: struct.UserHandle.html
+
+use std::{mem, os::raw, sync::Arc};
+
+pub type RawHandle = *mut raw::c_void;
+
+/// Type-erased [`Arc`], used to pass user-defined data types to the C API.
+///
+/// See the [module-level documentation](index.html) for more.
+///
+/// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct UserHandle {
+    raw: RawHandle,
+    clone_fn: unsafe fn(RawHandle) -> RawHandle,
+    drop_fn: unsafe fn(RawHandle),
+}
+
+impl UserHandle {
+    /// Creates a new type-erased handle from the specified data.
+    pub fn new<T>(data: T) -> Self {
+        Self {
+            raw: allocate_raw(data),
+            clone_fn: clone_raw::<T>,
+            drop_fn: drop_raw::<T>,
+        }
+    }
+
+    /// Reconstructs a handle from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function must be called with the correct type `T` for the specified handle.
+    /// Failing to do so will cause the data to be treated as the wrong type, which will
+    /// result in undefined behavior.
+    pub unsafe fn from_raw<T>(raw: RawHandle) -> Self {
+        Self {
+            raw,
+            clone_fn: clone_raw::<T>,
+            drop_fn: drop_raw::<T>,
+        }
+    }
+
+    /// Returns the raw version of the handle.
+    ///
+    /// This method doesn't consume the handle, and it will still be dropped when it
+    /// goes out of scope. If this is the last instance of this handle, that means the
+    /// handle's data will be freed. As such, the returned pointer is only safe to be
+    /// used while the full handle (or another handle to the same data) is still in
+    /// scope.
+    ///
+    /// When passing user handles to the C API functions like
+    /// `Worker_Connection_SendCreateEntityRequest`, the C API will make a clone of the
+    /// handle. This means it should be safe to drop the handle once the C API has had
+    /// a chance to make its own copy.
+    pub fn raw(&self) -> RawHandle {
+        self.raw
+    }
+}
+
+impl Clone for UserHandle {
+    fn clone(&self) -> Self {
+        let raw = unsafe { (self.clone_fn)(self.raw) };
+        Self {
+            raw,
+            clone_fn: self.clone_fn,
+            drop_fn: self.drop_fn,
+        }
+    }
+}
+
+impl Drop for UserHandle {
+    fn drop(&mut self) {
+        unsafe {
+            (self.drop_fn)(self.raw);
+        }
+    }
+}
+
+pub fn allocate_raw<T>(data: T) -> RawHandle {
+    Arc::into_raw(Arc::new(data)) as *mut _
+}
+
+pub unsafe fn drop_raw<T>(handle: RawHandle) {
+    let _ = Arc::<T>::from_raw(handle as *const _);
+}
+
+pub unsafe fn clone_raw<T>(handle: RawHandle) -> RawHandle {
+    let original = Arc::<T>::from_raw(handle as *const _);
+    let copy = original.clone();
+    mem::forget(original);
+    Arc::into_raw(copy) as *mut _
+}

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -6,6 +6,7 @@ pub mod component;
 pub mod connection;
 pub mod entity;
 pub mod entity_builder;
+pub mod handle;
 pub mod locator;
 pub mod metrics;
 pub mod op;

--- a/spatialos-sdk/src/worker/schema/owned.rs
+++ b/spatialos-sdk/src/worker/schema/owned.rs
@@ -35,9 +35,11 @@ pub trait Ownable: OwnableImpl {}
 
 impl<T> Ownable for T where T: OwnableImpl {}
 
-/// Like `Box`, but for SpatialOS schema types.
+/// Like [`Box`], but for SpatialOS schema types.
 ///
-/// See the [module-level documentation](./index.html) for more.
+/// See the [module-level documentation](index.html) for more.
+///
+/// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
 #[derive(Debug)]
 pub struct Owned<T: Ownable>(NonNull<T::Raw>);
 

--- a/spatialos-sdk/src/worker/snapshot.rs
+++ b/spatialos-sdk/src/worker/snapshot.rs
@@ -35,7 +35,7 @@ impl SnapshotOutputStream {
     }
 
     pub fn write_entity(&mut self, id: EntityId, entity: Entity) -> Result<(), String> {
-        let components = entity.into_raw();
+        let (components, _handles) = entity.into_raw();
 
         let wrk_entity = Worker_Entity {
             entity_id: id.id,

--- a/spatialos-sdk/tests/compile_fail/entity_add_send.rs
+++ b/spatialos-sdk/tests/compile_fail/entity_add_send.rs
@@ -1,0 +1,16 @@
+extern crate spatialos_sdk;
+
+use spatialos_sdk::dummy_component;
+use spatialos_sdk::worker::entity::Entity;
+use spatialos_sdk::worker::component::inventory;
+use std::{cell::RefCell, rc::Rc};
+
+pub struct TestComponent(Rc<RefCell<bool>>);
+dummy_component!(TestComponent, TestComponentUpdate);
+
+fn free_handle_on_drop_entity() {
+    let was_dropped = Rc::new(RefCell::new(false));
+    let mut entity = Entity::new();
+    let _ = entity.add_handle(TestComponent(was_dropped.clone()));
+    //~^ ERROR cannot be sent between threads safely
+}


### PR DESCRIPTION
I've added a new `UserHandle` type that handle the work of freeing the handle once we're done with it. It's meant to make it harder for use introduce memory leaks (such as the ones addressed in #93), while also making it easier to safely manage user handles (as `Entity` needs to do in order to support non-vtable serialization). I've still kept the existing free functions, since they're useful for the vtable functions (though I've renamed them to more accurately reflect their new role).