### PR TITLE
Add events to component updates (serialization rewrite)

### DIFF
--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -17,7 +17,6 @@ pub trait Component: SchemaObjectType {
     const ID: ComponentId;
 
     type Update: Update<Component = Self>;
-    type Events: Events<Component = Self>;
 }
 
 pub trait Update: Sized {
@@ -25,23 +24,6 @@ pub trait Update: Sized {
 
     fn from_update(update: &ComponentUpdate) -> Self;
     fn into_update(&self, update: &mut ComponentUpdate);
-}
-
-pub trait Events: Sized {
-    type Component: Component<Events = Self>;
-
-    fn from_update(update: &ComponentUpdate) -> Self;
-    fn into_update(&self, update: &mut ComponentUpdate);
-}
-
-pub struct UpdateData<C: Component> {
-    // TODO: Is it necessary to split fields and events into separate structs? This is
-    // only necessary if you're allowed to have an event with the same name as a field.
-    // If that's not allowed, then we can keep everything simple and generate a single
-    // struct that contains both the fields and events for an update. I should test it
-    // out and see whether or not the schema compiler allows it.
-    pub fields: C::Update,
-    pub events: C::Events,
 }
 
 /// Additional parameters for sending component updates.

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -17,6 +17,7 @@ pub trait Component: SchemaObjectType {
     const ID: ComponentId;
 
     type Update: Update<Component = Self>;
+    type Events: Events<Component = Self>;
 }
 
 pub trait Update: Sized {
@@ -24,6 +25,23 @@ pub trait Update: Sized {
 
     fn from_update(update: &ComponentUpdate) -> Self;
     fn into_update(&self, update: &mut ComponentUpdate);
+}
+
+pub trait Events: Sized {
+    type Component: Component<Events = Self>;
+
+    fn from_update(update: &ComponentUpdate) -> Self;
+    fn into_update(&self, update: &mut ComponentUpdate);
+}
+
+pub struct UpdateData<C: Component> {
+    // TODO: Is it necessary to split fields and events into separate structs? This is
+    // only necessary if you're allowed to have an event with the same name as a field.
+    // If that's not allowed, then we can keep everything simple and generate a single
+    // struct that contains both the fields and events for an update. I should test it
+    // out and see whether or not the schema compiler allows it.
+    pub fields: C::Update,
+    pub events: C::Events,
 }
 
 /// Additional parameters for sending component updates.

--- a/spatialos-sdk/tests/manual_serialization.rs
+++ b/spatialos-sdk/tests/manual_serialization.rs
@@ -12,7 +12,7 @@
 //!     NestedType nested = 6;
 //!     list<bool> events = 7;
 //!
-//!     event NestedType nested;
+//!     event NestedType nested_event;
 //!     event CoolEvent cool_event;
 //! }
 //!
@@ -69,12 +69,11 @@ impl SchemaObjectType for CustomComponent {
 
 impl Component for CustomComponent {
     const ID: ComponentId = 1234;
-    type Update = CustomComponentFieldsUpdate;
-    type Events = CustomComponentEvents;
+    type Update = CustomComponentUpdate;
 }
 
 #[allow(clippy::option_option)]
-pub struct CustomComponentFieldsUpdate {
+pub struct CustomComponentUpdate {
     pub name: Option<Option<String>>,
     pub count: Option<i32>,
     pub targets: Option<Vec<EntityId>>,
@@ -82,30 +81,12 @@ pub struct CustomComponentFieldsUpdate {
     pub byte_collection: Option<Vec<Vec<u8>>>,
     pub id: Option<Option<u32>>,
     pub nested: Option<NestedType>,
-}
 
-#[derive(Debug, Default)]
-pub struct CustomComponentEvents {
-    pub nested: Vec<NestedType>,
+    pub nested_event: Vec<NestedType>,
     pub cool_event: Vec<CoolEvent>,
 }
 
-impl Events for CustomComponentEvents {
-    type Component = CustomComponent;
-
-    fn from_update(update: &schema::ComponentUpdate) -> Self {
-        CustomComponentEvents {
-            nested: update.event::<NestedType>(1),
-            cool_event: update.event::<CoolEvent>(2),
-        }
-    }
-
-    fn into_update(&self, _update: &mut schema::ComponentUpdate) {
-        unimplemented!();
-    }
-}
-
-impl Update for CustomComponentFieldsUpdate {
+impl Update for CustomComponentUpdate {
     type Component = CustomComponent;
 
     fn from_update(update: &schema::ComponentUpdate) -> Self {
@@ -117,6 +98,9 @@ impl Update for CustomComponentFieldsUpdate {
             byte_collection: update.field::<Vec<Vec<u8>>>(4),
             id: update.field::<Option<SchemaUint32>>(5),
             nested: update.field::<NestedType>(6),
+
+            nested_event: update.event::<NestedType>(1),
+            cool_event: update.event::<CoolEvent>(2),
         }
     }
 
@@ -147,6 +131,14 @@ impl Update for CustomComponentFieldsUpdate {
 
         if let Some(nested) = &self.nested {
             update.add_field::<NestedType>(6, nested);
+        }
+
+        if !self.nested_event.is_empty() {
+            update.add_event(1, &self.nested_event);
+        }
+
+        if !self.cool_event.is_empty() {
+            update.add_event(2, &self.cool_event);
         }
     }
 }


### PR DESCRIPTION
Since component events and fields can't have the same name, we can add events directly to the generated component update type, which makes implementing events pretty trivial 😁 