### PR TITLE
WIP: Alternate ConnectionParameters to Worker_ConnectionParameters conversion

### DIFF
--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -1,5 +1,4 @@
 use crate::ptr::MutPtr;
-use crate::worker::parameters::ProtocolType;
 use crate::worker::{
     commands::*,
     component::{self, Component, UpdateParameters},

--- a/spatialos-sdk/src/worker/parameters.rs
+++ b/spatialos-sdk/src/worker/parameters.rs
@@ -88,10 +88,22 @@ impl ConnectionParameters {
             ProtocolType::Udp(params) => IntermediateProtocolType::Udp {
                 security_type: params.security_type.to_worker_sdk(),
                 kcp: params.kcp.as_ref().map(KcpParameters::to_worker_sdk),
-                erasure_codec: params.erasure_codec.as_ref().map(ErasureCodecParameters::to_worker_sdk),
-                heartbeat: params.heartbeat.as_ref().map(HeartbeatParameters::to_worker_sdk),
-                flow_control: params.flow_control.as_ref().map(FlowControlParameters::to_worker_sdk),
-            }
+
+                erasure_codec: params
+                    .erasure_codec
+                    .as_ref()
+                    .map(ErasureCodecParameters::to_worker_sdk),
+
+                heartbeat: params
+                    .heartbeat
+                    .as_ref()
+                    .map(HeartbeatParameters::to_worker_sdk),
+
+                flow_control: params
+                    .flow_control
+                    .as_ref()
+                    .map(FlowControlParameters::to_worker_sdk),
+            },
         };
 
         IntermediateConnectionParameters {
@@ -426,15 +438,13 @@ impl<'a> IntermediateConnectionParameters<'a> {
         };
 
         let network = match &self.protocol {
-            &IntermediateProtocolType::Tcp(tcp) => {
-                Worker_NetworkParameters {
-                    connection_type:
-                        Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_TCP as u8,
-                    tcp,
+            IntermediateProtocolType::Tcp(tcp) => Worker_NetworkParameters {
+                connection_type: Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_TCP
+                    as u8,
+                tcp: *tcp,
 
-                    ..partial_network_params
-                }
-            }
+                ..partial_network_params
+            },
 
             IntermediateProtocolType::Udp {
                 security_type,
@@ -443,15 +453,30 @@ impl<'a> IntermediateConnectionParameters<'a> {
                 heartbeat,
                 flow_control,
             } => {
-                let kcp = kcp.as_ref().map(|param| param as *const _).unwrap_or(ptr::null());
-                let erasure_codec = erasure_codec.as_ref().map(|param| param as *const _).unwrap_or(ptr::null());
-                let heartbeat = heartbeat.as_ref().map(|param| param as *const _).unwrap_or(ptr::null());
-                let flow_control = flow_control.as_ref().map(|param| param as *const _).unwrap_or(ptr::null());
+                let kcp = kcp
+                    .as_ref()
+                    .map(|param| param as *const _)
+                    .unwrap_or(ptr::null());
+
+                let erasure_codec = erasure_codec
+                    .as_ref()
+                    .map(|param| param as *const _)
+                    .unwrap_or(ptr::null());
+
+                let heartbeat = heartbeat
+                    .as_ref()
+                    .map(|param| param as *const _)
+                    .unwrap_or(ptr::null());
+
+                let flow_control = flow_control
+                    .as_ref()
+                    .map(|param| param as *const _)
+                    .unwrap_or(ptr::null());
 
                 Worker_NetworkParameters {
-
                     connection_type:
-                        Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_MODULAR_UDP as u8,
+                        Worker_NetworkConnectionType_WORKER_NETWORK_CONNECTION_TYPE_MODULAR_UDP
+                            as u8,
 
                     modular_udp: Worker_Alpha_ModularUdpNetworkParameters {
                         security_type: *security_type,
@@ -479,9 +504,12 @@ impl<'a> IntermediateConnectionParameters<'a> {
             send_queue_capacity: self.params.send_queue_capacity,
             receive_queue_capacity: self.params.receive_queue_capacity,
             log_message_queue_capacity: self.params.log_message_queue_capacity,
-            built_in_metrics_report_period_millis: self.params.built_in_metrics_report_period_millis,
+            built_in_metrics_report_period_millis: self
+                .params
+                .built_in_metrics_report_period_millis,
             protocol_logging: self.params.protocol_logging.to_worker_sdk(),
-            enable_protocol_logging_at_startup: self.params.enable_protocol_logging_at_startup as u8,
+            enable_protocol_logging_at_startup: self.params.enable_protocol_logging_at_startup
+                as u8,
             enable_dynamic_components: 0,
             thread_affinity: self.params.thread_affinity.to_worker_sdk(),
 
@@ -515,5 +543,5 @@ enum IntermediateProtocolType {
         erasure_codec: Option<Worker_ErasureCodecParameters>,
         heartbeat: Option<Worker_HeartbeatParameters>,
         flow_control: Option<Worker_Alpha_FlowControlParameters>,
-    }
+    },
 }


### PR DESCRIPTION
Sketch out an alternate approach to converting a `ConnectionParameters` to a `Worker_ConnectionParameters`, specifically using a different strategy for populating the various pointers hiding in `Worker_Alpha_ModularUdpNetworkParameters `.

This approach uses a new enum `IntermediateProtocolType` to "flatten" the contents of `ProtocolType::Udp` into the corresponding C structs on the stack. From there, we can populate the final `Worker_ConnectionParameters` from the values on the stack.

From a safety perspective, this is functionally equivalent to the closure-based approach implemented in #105, which is to say that it's *mostly* safe but can't completely statically prevent misuse due to the nature of FFI and using C structs. I'd personally argue that the intermediate struct approach is a bit cleaner and easier to understand because it doesn't take over control flow the way that a closure does, however that's ultimately a minor point in this particular situation.

---

This is currently not entirely done, but there's enough in place to make the approach clear. I'll try to finish it up over the next couple of days, but let me know what you think in the meantime. I think its worth discussing both approaches, since neither is obviously better than the other.