### PR TITLE
Checking in latest codegen

### DIFF
--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -71,6 +71,38 @@ impl TypeConversion for CommandData {
 }
 
 #[derive(Debug, Clone)]
+pub struct TestType {
+    pub value: i32,
+}
+impl TypeConversion for TestType {
+    fn from_type(input: &SchemaObject) -> Result<Self, String> {
+        Ok(Self {
+            value: input.field::<SchemaInt32>(1).get_or_default(),
+        })
+    }
+    fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
+        output.field::<SchemaInt32>(1).add(input.value);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TestType_Inner {
+    pub number: f32,
+}
+impl TypeConversion for TestType_Inner {
+    fn from_type(input: &SchemaObject) -> Result<Self, String> {
+        Ok(Self {
+            number: input.field::<SchemaFloat>(2).get_or_default(),
+        })
+    }
+    fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
+        output.field::<SchemaFloat>(2).add(input.number);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Vector3d {
     pub x: f64,
     pub y: f64,


### PR DESCRIPTION
Also, how do you feel about checking in the files, generally?

Against checking-in, on principle version control systems really only ought to track human-generated content.

However, the idiosyncrasies of a build system sometimes lend to more convenience. For example, my workflow (VScode + RLS) fails on a clean checkout if I haven't run the cargo spatial codegen command. I'm not sure if this would work differently if the generated code were managed by a build.rs script. What good looks like, in my opinion, is [Pants Java Protobuf](https://www.pantsbuild.org/build_dictionary.html#bdict_java_protobuf_library) which seamlessly links generated code to your classpath (and IDE) without requiring the generated code to be checked-in.