### PR TITLE
Add option to download test schema

### DIFF
--- a/cargo-spatial/Cargo.toml
+++ b/cargo-spatial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-spatial"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "David LeGare <dlegare.1001@gmail.com>",
     "David Avedissian <git@dga.dev>",

--- a/cargo-spatial/src/opt.rs
+++ b/cargo-spatial/src/opt.rs
@@ -102,4 +102,8 @@ pub struct DownloadSdk {
     /// Overrides the SDK version in Spatial.toml
     #[structopt(long, short)]
     pub sdk_version: Option<String>,
+
+    /// Downloads the exhaustive test schema.
+    #[structopt(long, short)]
+    pub with_test_schema: bool,
 }


### PR DESCRIPTION
Somewhere in the `13.x` releases, a new package was published which contains exhaustive test schema. This test schema is meant to test code generators and ensure they can generate valid code for the schema spec.

In preparation for actually doing this testing, this PR adds an optional flag to `cargo spatial download sdk` that will download the test schema into: 

```
sdk_dir/test-schema
```