### PR TITLE
Use Github actions 

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Install Rust
-        if: matrix.os == "macOS-latest"
+        if: matrix.os == 'macOS-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -26,9 +26,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: spatial
-          args: download sdk
+          args: download sdk --sdk-version 14.0.0
+        env:
+          SPATIAL_LIB_DIR="dependencies"
       
       - name: Build crates
         uses: actions-rs/cargo@v1
         with:
           command: build
+        env:
+          SPATIAL_LIB_DIR="dependencies"        

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -26,9 +26,19 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: spatial
-          args: download sdk --sdk-version 14.0.0
+          args: --verbose download sdk --sdk-version 14.0.0
         env:
           SPATIAL_LIB_DIR: "dependencies"
+
+      - name: Generate project-example code
+        runs: pushd project-example && cargo spatial --verbose codegen && popd
+        env:
+          SPATIAL_LIB_DIR: "../dependencies"
+
+      - name: Generate test-suite code
+        runs: pushd test-suite && mkdir schema && cargo spatial --verbose codegen && popd
+        env:
+          SPATIAL_LIB_DIR: "../dependencies"
       
       - name: Build crates
         uses: actions-rs/cargo@v1

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -31,12 +31,12 @@ jobs:
           SPATIAL_LIB_DIR: "dependencies"
 
       - name: Generate project-example code
-        runs: pushd project-example && cargo spatial --verbose codegen && popd
+        run: pushd project-example && cargo spatial --verbose codegen && popd
         env:
           SPATIAL_LIB_DIR: "../dependencies"
 
       - name: Generate test-suite code
-        runs: pushd test-suite && mkdir schema && cargo spatial --verbose codegen && popd
+        run: pushd test-suite && mkdir schema && cargo spatial --verbose codegen && popd
         env:
           SPATIAL_LIB_DIR: "../dependencies"
       

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -7,25 +7,31 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout source
+        uses: actions/checkout@master
 
-      - uses: jamiebrynes7/get-spatial-cli-action@v1
+      - name: Install spatial
+        uses: jamiebrynes7/get-spatial-cli-action@v1
         with:
           version: 20190416.094616.a865bb5b54
           oauth_token: ${{ secrets.SPATIAL_OAUTH_TOKEN }}
 
-      - uses: actions-rs/cargo@v1
+      - name: Install cargo-spatial
+        uses: actions-rs/cargo@v1
         with:
           command: install
           args: --path ./cargo-spatial --force
       
-      - run: export SPATIAL_LIB_DIR=$(pwd)/dependencies
+      - name: Set SPATIAL_LIB_DIR environment variable
+        run: export SPATIAL_LIB_DIR=$(pwd)/dependencies
 
-      - uses: actions-rs/cargo@v1
+      - name: Install SpatialOS C API dependencies
+        uses: actions-rs/cargo@v1
         with:
           command: spatial
           args: download sdk --sdk-version 14.0.0
       
-      - uses: actions-rs/cargo@v1
+      - name: Build crates
+        uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -28,11 +28,11 @@ jobs:
           command: spatial
           args: download sdk --sdk-version 14.0.0
         env:
-          SPATIAL_LIB_DIR="dependencies"
+          SPATIAL_LIB_DIR: "dependencies"
       
       - name: Build crates
         uses: actions-rs/cargo@v1
         with:
           command: build
         env:
-          SPATIAL_LIB_DIR="dependencies"        
+          SPATIAL_LIB_DIR: "dependencies"        

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -1,0 +1,15 @@
+on: [push]
+
+name: Premerge checks
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: jamiebrynes7/get-spatial-cli-action@v1
+        with:
+          version: 20190416.094616.a865bb5b54
+          oauth_token: ${{ secrets.SPATIAL_OAUTH_TOKEN }}
+      - run: spatial version

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env: 
-      SPATIAL_LIB_DIR=${{ GITHUB_WORKSPACE }}/dependencies
+      SPATIAL_LIB_DIR=${{ $GITHUB_WORKSPACE }}/dependencies
     steps:
       - name: Checkout source
         uses: actions/checkout@master

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -10,6 +10,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@master
 
+      - name: Install Rust components
+        run: rustup component add rustfmt clippy
+
       - name: Install spatial
         uses: jamiebrynes7/get-spatial-cli-action@v1
         with:
@@ -39,10 +42,33 @@ jobs:
         run: pushd test-suite && mkdir schema && cargo spatial --verbose codegen && popd
         env:
           SPATIAL_LIB_DIR: "../dependencies"
-      
+        
+      - name: Lint
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+        env:
+          SPATIAL_LIB_DIR: "dependencies"
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --all-features -- -D warnings -A dead-code
+        env:
+          SPATIAL_LIB_DIR: "dependencies"
+
       - name: Build crates
         uses: actions-rs/cargo@v1
         with:
           command: build
         env:
-          SPATIAL_LIB_DIR: "dependencies"        
+          SPATIAL_LIB_DIR: "dependencies"
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          SPATIAL_LIB_DIR: "dependencies"          

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -8,8 +8,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
       - uses: jamiebrynes7/get-spatial-cli-action@v1
         with:
           version: 20190416.094616.a865bb5b54
           oauth_token: ${{ secrets.SPATIAL_OAUTH_TOKEN }}
-      - run: spatial version
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --path ./cargo-spatial --force
+      
+      - run: export SPATIAL_LIB_DIR=$(pwd)/dependencies
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: spatial
+          args: download sdk --sdk-version 14.0.0
+      
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -7,7 +7,6 @@ jobs:
     name: Build
     strategy:
       matrix:
-        # TODO: Add windows-latest when https://github.com/jamiebrynes7/get-spatial-cli-action/issues/1 is resolved.
         os: [ubuntu-latest, macOS-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,7 +23,7 @@ jobs:
         run: rustup component add rustfmt clippy
 
       - name: Install spatial
-        uses: jamiebrynes7/get-spatial-cli-action@releases/v1.1
+        uses: jamiebrynes7/get-spatial-cli-action@v1.1
         with:
           version: 20190416.094616.a865bb5b54
           oauth_token: ${{ secrets.SPATIAL_OAUTH_TOKEN }}

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -24,7 +24,7 @@ jobs:
         run: rustup component add rustfmt clippy
 
       - name: Install spatial
-        uses: jamiebrynes7/get-spatial-cli-action@master
+        uses: jamiebrynes7/get-spatial-cli-action@releases/v1.1
         with:
           version: 20190416.094616.a865bb5b54
           oauth_token: ${{ secrets.SPATIAL_OAUTH_TOKEN }}

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -6,11 +6,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env: 
+      SPATIAL_LIB_DIR=${{ GITHUB_WORKSPACE }}/dependencies
     steps:
       - name: Checkout source
         uses: actions/checkout@master
-
-      - run: echo $PATH
 
       - name: Install spatial
         uses: jamiebrynes7/get-spatial-cli-action@v1
@@ -23,9 +23,6 @@ jobs:
         with:
           command: install
           args: --path ./cargo-spatial --force
-      
-      - name: Set SPATIAL_LIB_DIR environment variable
-        run: export SPATIAL_LIB_DIR=$(pwd)/dependencies
 
       - name: Install SpatialOS C API dependencies
         uses: actions-rs/cargo@v1

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env: 
-      SPATIAL_LIB_DIR=${{ $GITHUB_WORKSPACE }}/dependencies
+      SPATIAL_LIB_DIR=${{ env.GITHUB_WORKSPACE }}/dependencies
     steps:
       - name: Checkout source
         uses: actions/checkout@master

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -5,10 +5,19 @@ name: Premerge checks
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout source
         uses: actions/checkout@master
+
+      - name: Install Rust
+        if: matrix.os == "macOS-latest"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -6,8 +6,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env: 
-      SPATIAL_LIB_DIR=${{ env.GITHUB_WORKSPACE }}/dependencies
     steps:
       - name: Checkout source
         uses: actions/checkout@master
@@ -28,7 +26,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: spatial
-          args: download sdk --sdk-version 14.0.0
+          args: download sdk
       
       - name: Build crates
         uses: actions-rs/cargo@v1

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -7,7 +7,8 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # TODO: Add windows-latest when https://github.com/jamiebrynes7/get-spatial-cli-action/issues/1 is resolved.
+        os: [ubuntu-latest, macOS-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout source

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -62,6 +62,7 @@ jobs:
           SPATIAL_LIB_DIR: "dependencies"
 
       - name: Clippy
+        if: matrix.os == 'macOS-latest' # Only need to run this once and MacOS machines appear to be the fastest.
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         # TODO: Add windows-latest when https://github.com/jamiebrynes7/get-spatial-cli-action/issues/1 is resolved.
-        os: [ubuntu-latest, macOS-latest ]
+        os: [ubuntu-latest, macOS-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout source
@@ -24,7 +24,7 @@ jobs:
         run: rustup component add rustfmt clippy
 
       - name: Install spatial
-        uses: jamiebrynes7/get-spatial-cli-action@v1
+        uses: jamiebrynes7/get-spatial-cli-action@master
         with:
           version: 20190416.094616.a865bb5b54
           oauth_token: ${{ secrets.SPATIAL_OAUTH_TOKEN }}

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -10,6 +10,8 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@master
 
+      - run: echo $PATH
+
       - name: Install spatial
         uses: jamiebrynes7/get-spatial-cli-action@v1
         with:

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -71,4 +71,12 @@ jobs:
         with:
           command: test
         env:
-          SPATIAL_LIB_DIR: "dependencies"          
+          SPATIAL_LIB_DIR: "dependencies"      
+
+      - name: Build examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --examples
+        env:
+          SPATIAL_LIB_DIR: "dependencies"

--- a/Spatial.toml
+++ b/Spatial.toml
@@ -1,0 +1,2 @@
+spatial_lib_dir = "dependencies"
+spatial_sdk_version = "14.0.0"

--- a/Spatial.toml
+++ b/Spatial.toml
@@ -1,2 +1,0 @@
-spatial_lib_dir = "dependencies"
-spatial_sdk_version = "14.0.0"

--- a/cargo-spatial/src/config.rs
+++ b/cargo-spatial/src/config.rs
@@ -53,7 +53,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            spatial_sdk_version: "13.6.0".into(),
+            spatial_sdk_version: "14.0.0".into(),
             workers: vec![".".into()],
             codegen_out: "src/generated.rs".into(),
             schema_paths: vec!["./schema".into()],


### PR DESCRIPTION
I'm planning to drop support for Travis CI and replace it with GitHub Actions due to:

- Code reusability for components of CI.
- Better GitHub integration (annotations, etc.)
- Better Windows support

This PR introduces a GitHub Actions pipeline that should act as a pre-merge check. It replicates the current Travis CI behaviour. As a bonus, it runs noticeably faster!  