### PR TITLE
Add `Copy` to `UpdateParameters` and `CommandParameters`

### DIFF
--- a/spatialos-sdk/src/worker/commands.rs
+++ b/spatialos-sdk/src/worker/commands.rs
@@ -46,7 +46,7 @@ impl CommandParameters {
         self.allow_short_circuit = true;
     }
 
-    pub(crate) fn to_worker_sdk(&self) -> Worker_CommandParameters {
+    pub(crate) fn to_worker_sdk(self) -> Worker_CommandParameters {
         Worker_CommandParameters {
             allow_short_circuit: self.allow_short_circuit as u8,
         }

--- a/spatialos-sdk/src/worker/commands.rs
+++ b/spatialos-sdk/src/worker/commands.rs
@@ -28,9 +28,9 @@ use spatialos_sdk_sys::worker::Worker_CommandParameters;
 ///     .tap(CommandParameters::allow_short_circuit);
 /// ```
 ///
-/// [short-circuit]: https://docs.improbable.io/reference/13.5/shared/design/commands#properties
+/// [short-circuit]: https://docs.improbable.io/reference/14.1/shared/design/commands#component-commands
 /// [tap]: https://crates.io/crates/tap
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CommandParameters {
     allow_short_circuit: bool,
 }

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -91,7 +91,7 @@ where
 /// ```
 ///
 /// [tap]: https://crates.io/crates/tap
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct UpdateParameters {
     loopback: bool,
 }

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -110,7 +110,7 @@ impl UpdateParameters {
         self.loopback = true;
     }
 
-    pub(crate) fn to_worker_sdk(&self) -> Worker_UpdateParameters {
+    pub(crate) fn to_worker_sdk(self) -> Worker_UpdateParameters {
         Worker_UpdateParameters {
             loopback: if self.loopback {
                 Worker_ComponentUpdateLoopback_WORKER_COMPONENT_UPDATE_LOOPBACK_SHORT_CIRCUITED as _


### PR DESCRIPTION
One note I had when writing user code is that manually cloning the parameters everywhere is really annoying. 

Given they are small structs and are likely to remain so in the future, this feels like a safe thing to do.

Also driveby updated a docs link