### PR TITLE
Allow users not to have a `schema` directory 

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -48,7 +48,7 @@ jobs:
           SPATIAL_LIB_DIR: "../dependencies"
 
       - name: Generate test-suite code
-        run: pushd test-suite && mkdir schema && cargo spatial --verbose codegen && popd
+        run: pushd test-suite && cargo spatial --verbose codegen && popd
         env:
           SPATIAL_LIB_DIR: "../dependencies"
         

--- a/cargo-spatial/Cargo.toml
+++ b/cargo-spatial/Cargo.toml
@@ -19,6 +19,5 @@ serde = { version = "1.0.38", features = ["derive"] }
 serde_json = "1.0.38"
 spatialos-sdk-code-generator = { path = "../spatialos-sdk-code-generator" }
 structopt = "0.3"
-tap = "0.4"
 tempfile = "3.0"
 toml = "0.5"

--- a/cargo-spatial/Cargo.toml
+++ b/cargo-spatial/Cargo.toml
@@ -9,8 +9,6 @@ authors = [
 edition = "2018"
 
 [dependencies]
-glob = "0.3"
-lazy_static = "1.3"
 log = "0.4.1"
 rand = "0.7"
 reqwest = "0.9.13"

--- a/cargo-spatial/src/config.rs
+++ b/cargo-spatial/src/config.rs
@@ -56,7 +56,7 @@ impl Default for Config {
             spatial_sdk_version: "14.0.0".into(),
             workers: vec![".".into()],
             codegen_out: "src/generated.rs".into(),
-            schema_paths: vec!["./schema".into()],
+            schema_paths: vec![],
             build_dir: "./build".into(),
             schema_build_dir: None,
             spatial_lib_dir: None,

--- a/cargo-spatial/src/lib.rs
+++ b/cargo-spatial/src/lib.rs
@@ -33,7 +33,7 @@ pub fn current_dir_is_root() -> bool {
 
 /// Formats an key-value pair into an argument string.
 pub fn format_arg<S: AsRef<OsStr>>(prefix: &str, value: S) -> OsString {
-    let mut arg = OsString::from(format!("--{}", prefix));
+    let mut arg = OsString::from(format!("--{}=", prefix));
     arg.push(value.as_ref());
     arg
 }

--- a/cargo-spatial/src/lib.rs
+++ b/cargo-spatial/src/lib.rs
@@ -1,3 +1,5 @@
+use std::ffi::{OsStr, OsString};
+
 pub mod codegen;
 pub mod config;
 pub mod download;
@@ -27,4 +29,11 @@ pub fn generate_component_id() -> i32 {
 /// `Spatial.toml` file).
 pub fn current_dir_is_root() -> bool {
     std::path::Path::new("./Spatial.toml").exists()
+}
+
+/// Formats an key-value pair into an argument string.
+pub fn format_arg<S: AsRef<OsStr>>(prefix: &str, value: S) -> OsString {
+    let mut arg = OsString::from(format!("--{}", prefix));
+    arg.push(value.as_ref());
+    arg
 }

--- a/cargo-spatial/src/local.rs
+++ b/cargo-spatial/src/local.rs
@@ -1,9 +1,8 @@
 use crate::config::{BuildProfile, Config};
+use crate::format_arg;
 use crate::opt::*;
-use std::ffi::OsString;
 use std::path::*;
 use std::process;
-use tap::*;
 
 /// Prepares and launches a local deployment.
 ///
@@ -59,8 +58,7 @@ pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Box<dyn std::
     let mut command = process::Command::new("spatial");
     command.args(&["alpha", "local", "launch"]);
     if let Some(launch_config) = &launch.launch_config {
-        let arg = OsString::from("--launch_config=").tap(|arg| arg.push(launch_config));
-        command.arg(arg);
+        command.arg(&format_arg("launch_config", launch_config));
     }
     command
         .status()

--- a/project-example/Spatial.toml
+++ b/project-example/Spatial.toml
@@ -1,0 +1,1 @@
+schema_paths = ["./schema"]


### PR DESCRIPTION
In `cargo-spatial` we assumed that there would be a `schema` directory next to the `Spatial.toml`. This may not be true, as is the case with our `test-suite` crate.

This PR removes the default assumption of this `schema` directory and removes some unused/low-impact dependencies for the `cargo-spatial` tool.