### PR TITLE
add default snapshot to project config

### DIFF
--- a/project-example/spatialos.json
+++ b/project-example/spatialos.json
@@ -8,5 +8,6 @@
   "clientWorkers": [
     "./rust_client.json"
   ],
-  "launchConfiguration": "world.json"
+  "launchConfiguration": "world.json",
+  "defaultSnapshotUploadFilepath": "./snapshots/default.snapshot"
 }


### PR DESCRIPTION
This fixes the following bug when running `cargo spatial local launch`

```
Encountered an error during command execution.                                 Snapshot file is not set. Please provide a snapshot file using either t
he --snapshot flag or the 'defaultSnapshotUploadFilepath' field under 'snapshot' in the project configuration file
```

Could be that there's an alternative approach, but this felt easy enough.