### PR TITLE
add default snapshot to project config

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -44,11 +44,13 @@ jobs:
 
       - name: Generate project-example code
         run: pushd project-example && cargo spatial --verbose codegen && popd
+        shell: bash
         env:
           SPATIAL_LIB_DIR: "../dependencies"
 
       - name: Generate test-suite code
         run: pushd test-suite && cargo spatial --verbose codegen && popd
+        shell: bash
         env:
           SPATIAL_LIB_DIR: "../dependencies"
         

--- a/project-example/spatialos.json
+++ b/project-example/spatialos.json
@@ -8,5 +8,6 @@
   "clientWorkers": [
     "./rust_client.json"
   ],
-  "launchConfiguration": "world.json"
+  "launchConfiguration": "world.json",
+  "defaultSnapshotUploadFilepath": "./snapshots/default.snapshot"
 }


### PR DESCRIPTION
> Duped from #118 such that CI can run 

This fixes the following bug when running `cargo spatial local launch`

```
Encountered an error during command execution.                                 Snapshot file is not set. Please provide a snapshot file using either t
he --snapshot flag or the 'defaultSnapshotUploadFilepath' field under 'snapshot' in the project configuration file
```

Could be that there's an alternative approach, but this felt easy enough.