### PR TITLE
Small speed up to CI

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --path ./cargo-spatial --force
+          args: --path ./cargo-spatial --force --debug
 
       - name: Install SpatialOS C API dependencies
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Install `cargo spatial` in debug mode. Sacrifices `cargo spatial` execution time for compile time.