### PR TITLE
Fix soundness holes in SchemaObject

### DIFF
--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -13,6 +13,7 @@ spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
 futures = "0.1"
 inventory = "0.1"
 lazy_static = "1.3"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -13,8 +13,8 @@ spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
 futures = "0.1"
 inventory = "0.1"
 lazy_static = "1.3"
-static_assertions = "1.1.0"
 
 [dev-dependencies]
+static_assertions = "1.1.0"
 structopt = "0.3"
 tap="0.4"

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -118,9 +118,9 @@ impl EntityBuilder {
     // before we call `entity.add_serialized`?
     fn serialize_position(&self) -> SchemaComponentData {
         let mut position_schema = SchemaComponentData::new();
-        let mut position_fields = position_schema.fields_mut();
+        let position_fields = position_schema.fields_mut();
 
-        let mut coords_obj = position_fields.add_object(1);
+        let coords_obj = position_fields.add_object(1);
         coords_obj.add::<SchemaDouble>(1, &self.position.0);
         coords_obj.add::<SchemaDouble>(2, &self.position.1);
         coords_obj.add::<SchemaDouble>(3, &self.position.2);
@@ -130,16 +130,16 @@ impl EntityBuilder {
 
     fn serialize_acl(&self) -> SchemaComponentData {
         let mut acl_schema = SchemaComponentData::new();
-        let mut acl_fields = acl_schema.fields_mut();
+        let acl_fields = acl_schema.fields_mut();
 
-        let mut read_access = acl_fields.add_object(1);
+        let read_access = acl_fields.add_object(1);
         for layer in &self.read_permissions {
-            let mut attribute_set = read_access.add_object(1);
+            let attribute_set = read_access.add_object(1);
             attribute_set.add::<SchemaString>(1, layer);
         }
 
         for pair in &self.write_permissions {
-            let mut map_obj = acl_fields.add_object(2);
+            let map_obj = acl_fields.add_object(2);
             map_obj.add::<SchemaUint32>(1, pair.0);
 
             map_obj
@@ -153,7 +153,7 @@ impl EntityBuilder {
 
     fn serialize_metadata(&self) -> SchemaComponentData {
         let mut metadata_schema = SchemaComponentData::new();
-        let mut metadata_fields = metadata_schema.fields_mut();
+        let metadata_fields = metadata_schema.fields_mut();
         metadata_fields.add::<SchemaString>(1, self.metadata.as_ref().unwrap());
 
         metadata_schema

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -13,16 +13,12 @@ impl SchemaCommandRequest {
         }
     }
 
-    pub fn object(&self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetCommandRequestObject(self.internal) },
-        }
+    pub fn object(&self) -> &SchemaObject {
+        unsafe { SchemaObject::from_raw(Schema_GetCommandRequestObject(self.internal)) }
     }
 
-    pub fn object_mut(&mut self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetCommandRequestObject(self.internal) },
-        }
+    pub fn object_mut(&mut self) -> &mut SchemaObject {
+        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandRequestObject(self.internal)) }
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -13,16 +13,12 @@ impl SchemaCommandResponse {
         }
     }
 
-    pub fn object(&self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetCommandResponseObject(self.internal) },
-        }
+    pub fn object(&self) -> &SchemaObject {
+        unsafe { SchemaObject::from_raw(Schema_GetCommandResponseObject(self.internal)) }
     }
 
-    pub fn object_mut(&mut self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetCommandResponseObject(self.internal) },
-        }
+    pub fn object_mut(&mut self) -> &mut SchemaObject {
+        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandResponseObject(self.internal)) }
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -13,16 +13,12 @@ impl SchemaComponentData {
         }
     }
 
-    pub fn fields(&self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetComponentDataFields(self.internal) },
-        }
+    pub fn fields(&self) -> &SchemaObject {
+        unsafe { SchemaObject::from_raw(Schema_GetComponentDataFields(self.internal)) }
     }
 
-    pub fn fields_mut(&mut self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetComponentDataFields(self.internal) },
-        }
+    pub fn fields_mut(&mut self) -> &mut SchemaObject {
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentDataFields(self.internal)) }
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -13,28 +13,20 @@ impl SchemaComponentUpdate {
         }
     }
 
-    pub fn fields(&self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetComponentUpdateFields(self.internal) },
-        }
+    pub fn fields(&self) -> &SchemaObject {
+        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateFields(self.internal)) }
     }
 
-    pub fn fields_mut(&mut self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetComponentUpdateFields(self.internal) },
-        }
+    pub fn fields_mut(&mut self) -> &mut SchemaObject {
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateFields(self.internal)) }
     }
 
-    pub fn events(&self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetComponentUpdateEvents(self.internal) },
-        }
+    pub fn events(&self) -> &SchemaObject {
+        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateEvents(self.internal)) }
     }
 
-    pub fn events_mut(&mut self) -> SchemaObject {
-        SchemaObject {
-            internal: unsafe { Schema_GetComponentUpdateEvents(self.internal) },
-        }
+    pub fn events_mut(&mut self) -> &mut SchemaObject {
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateEvents(self.internal)) }
     }
 
     // TODO: Cleared fields.

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -64,5 +64,11 @@ impl SchemaObject {
     }
 }
 
+// SAFETY: It should be safe to send a `SchemaObject` between threads, so long as
+// it's only ever accessed from one thread at a time. It has unsynchronized internal
+// mutability (when getting an object field, it will automatically add a new object
+// if one doesn't already exist), so it cannot be `Sync`.
+unsafe impl Send for SchemaObject {}
+
 assert_impl_all!(SchemaObject: Send);
 assert_not_impl_any!(SchemaObject: Sync);

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -1,6 +1,5 @@
 use crate::worker::schema::{FieldId, SchemaPrimitiveField};
 use spatialos_sdk_sys::worker::*;
-use static_assertions::*;
 use std::marker::PhantomData;
 
 #[derive(Debug)]
@@ -70,5 +69,11 @@ impl SchemaObject {
 // if one doesn't already exist), so it cannot be `Sync`.
 unsafe impl Send for SchemaObject {}
 
-assert_impl_all!(SchemaObject: Send);
-assert_not_impl_any!(SchemaObject: Sync);
+#[cfg(test)]
+mod test {
+    use super::SchemaObject;
+    use static_assertions::*;
+
+    assert_impl_all!(SchemaObject: Send);
+    assert_not_impl_any!(SchemaObject: Sync);
+}

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -1,10 +1,10 @@
 use crate::worker::schema::{FieldId, SchemaPrimitiveField};
 use spatialos_sdk_sys::worker::*;
+use static_assertions::*;
+use std::marker::PhantomData;
 
 #[derive(Debug)]
-pub struct SchemaObject {
-    pub(crate) internal: *mut Schema_Object,
-}
+pub struct SchemaObject(PhantomData<*mut Schema_Object>);
 
 impl SchemaObject {
     pub fn get<T: SchemaPrimitiveField>(&self, field: FieldId) -> T::RustType {
@@ -31,26 +31,38 @@ impl SchemaObject {
         T::add_list(self, field, value);
     }
 
-    // TODO: Hook up the lifetimes of the schema objects. This is unsound as it exists now.
-    pub fn get_object(&self, field: FieldId) -> SchemaObject {
-        let internal = unsafe { Schema_GetObject(self.internal, field) };
-        SchemaObject { internal }
+    pub fn get_object(&self, field: FieldId) -> &SchemaObject {
+        unsafe { Self::from_raw(Schema_GetObject(self.as_ptr(), field)) }
     }
 
     pub fn object_count(&self, field: FieldId) -> usize {
-        let count = unsafe { Schema_GetObjectCount(self.internal, field) };
+        let count = unsafe { Schema_GetObjectCount(self.as_ptr(), field) };
         count as usize
     }
 
-    // TODO: Hook up the lifetimes of the schema objects. This is unsound as it exists now.
-    pub fn index_object(&self, field: FieldId, index: usize) -> SchemaObject {
-        let internal = unsafe { Schema_IndexObject(self.internal, field, index as u32) };
-        SchemaObject { internal }
+    pub fn index_object(&self, field: FieldId, index: usize) -> &SchemaObject {
+        unsafe { Self::from_raw(Schema_IndexObject(self.as_ptr(), field, index as u32)) }
     }
 
-    // TODO: Hook up the lifetimes of the schema objects. This is unsound as it exists now.
-    pub fn add_object(&mut self, field: FieldId) -> SchemaObject {
-        let internal = unsafe { Schema_AddObject(self.internal, field) };
-        SchemaObject { internal }
+    pub fn add_object(&mut self, field: FieldId) -> &mut SchemaObject {
+        unsafe { Self::from_raw_mut(Schema_AddObject(self.as_ptr(), field)) }
+    }
+
+    // Methods for raw pointer conversion.
+    // -----------------------------------
+
+    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_Object) -> &'a Self {
+        &*(raw as *mut _)
+    }
+
+    pub(crate) unsafe fn from_raw_mut<'a>(raw: *mut Schema_Object) -> &'a mut Self {
+        &mut *(raw as *mut _)
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut Schema_Object {
+        self as *const _ as *mut _
     }
 }
+
+assert_impl_all!(SchemaObject: Send);
+assert_not_impl_any!(SchemaObject: Sync);


### PR DESCRIPTION
> Part of #121 

This is the first of the schema data object soundness fixes. It follows the pattern described in #101 to make the schema data types sound. In summary:

* Make `SchemaObject` an opaque type that is never actually instantiated.
* Cast and dereference a `*mut Schema_Object` to either a `&SchemaObject` or a `&mut SchemaObject`, depending on what is valid for the context.
* Internally within the SDK, convert a `&SchemaObject` or `&mut SchemaObject` back to a `*mut Schema_Object` to pass into the C API.

This provides an idiomatic Rust API that allows us to correctly track lifetimes and enforce mutability constraints.

---

For the most part, this required very little change to the internals of the SDK or public API, and no changes to code generation. We were already passing `&SchemaObject` to any functions, so the only public facing changes were to change functions that returned a `SchemaObject` to instead return either a `&SchemaObject` or `&mut SchemaObject`.

Internally, the only changes were to how we construct `SchemaObject` instances and how we access the raw pointer from them.

Should be fairly straightforward overall :grin: