### PR TITLE
SchemaComponentData soundness

### DIFF
--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -13,9 +13,7 @@ use std::collections::BTreeMap;
 use super::generated as generated;
 
 /* Enums. */
-
 /* Types. */
-
 /* Components. */ 
 
 
@@ -55,79 +53,54 @@ impl TestEnum {
     }
 }
 
-
-
 /* Types. */
-
-
 #[derive(Debug, Clone)]
 pub struct CommandData {
     pub value: i32,
 }
-
 impl TypeConversion for CommandData {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             value: input.get::<SchemaInt32>(1),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaInt32>(1, &input.value);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct TestType {
     pub value: i32,
 }
-
 impl TypeConversion for TestType {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             value: input.get::<SchemaInt32>(1),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaInt32>(1, &input.value);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct TestType_Inner {
     pub number: f32,
 }
-
 impl TypeConversion for TestType_Inner {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             number: input.get::<SchemaFloat>(2),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaFloat>(2, &input.number);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct Vector3d {
@@ -135,31 +108,21 @@ pub struct Vector3d {
     pub y: f64,
     pub z: f64,
 }
-
 impl TypeConversion for Vector3d {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             x: input.get::<SchemaDouble>(1),
-            
             y: input.get::<SchemaDouble>(2),
-            
             z: input.get::<SchemaDouble>(3),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaDouble>(1, &input.x);
-        
         output.add::<SchemaDouble>(2, &input.y);
-        
         output.add::<SchemaDouble>(3, &input.z);
-        
         Ok(())
     }
 }
-
 
 /* Components. */ 
 #[derive(Debug, Clone)]
@@ -241,7 +204,7 @@ impl Component for EntityIdTest {
         }
     }
 
-    fn to_data(data: &generated::example::EntityIdTest) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::example::EntityIdTest) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::example::EntityIdTest as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -363,7 +326,7 @@ impl Component for EnumTestComponent {
         }
     }
 
-    fn to_data(data: &generated::example::EnumTestComponent) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::example::EnumTestComponent) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::example::EnumTestComponent as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -495,7 +458,7 @@ impl Component for Example {
         }
     }
 
-    fn to_data(data: &generated::example::Example) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::example::Example) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::example::Example as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -645,7 +608,7 @@ impl Component for Rotate {
         }
     }
 
-    fn to_data(data: &generated::example::Rotate) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::example::Rotate) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::example::Rotate as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -699,88 +662,60 @@ use std::collections::BTreeMap;
 use super::super::generated as generated;
 
 /* Enums. */
-
 /* Types. */
-
-
 #[derive(Debug, Clone)]
 pub struct ComponentInterest {
     pub queries: Vec<generated::improbable::ComponentInterest_Query>,
 }
-
 impl TypeConversion for ComponentInterest {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             queries: { let size = input.object_count(1); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::ComponentInterest_Query as TypeConversion>::from_type(&input.index_object(1, i))?); } l },
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         for element in (&input.queries).iter() { <generated::improbable::ComponentInterest_Query as TypeConversion>::to_type(&element, &mut output.add_object(1))?; };
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_BoxConstraint {
     pub center: generated::improbable::Coordinates,
     pub edge_length: generated::improbable::EdgeLength,
 }
-
 impl TypeConversion for ComponentInterest_BoxConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             center: <generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?,
-            
             edge_length: <generated::improbable::EdgeLength as TypeConversion>::from_type(&input.get_object(2))?,
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         <generated::improbable::Coordinates as TypeConversion>::to_type(&&input.center, &mut output.add_object(1))?;
-        
         <generated::improbable::EdgeLength as TypeConversion>::to_type(&&input.edge_length, &mut output.add_object(2))?;
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_CylinderConstraint {
     pub center: generated::improbable::Coordinates,
     pub radius: f64,
 }
-
 impl TypeConversion for ComponentInterest_CylinderConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             center: <generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?,
-            
             radius: input.get::<SchemaDouble>(2),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         <generated::improbable::Coordinates as TypeConversion>::to_type(&&input.center, &mut output.add_object(1))?;
-        
         output.add::<SchemaDouble>(2, &input.radius);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_Query {
@@ -789,36 +724,23 @@ pub struct ComponentInterest_Query {
     pub result_component_id: Vec<u32>,
     pub frequency: Option<f32>,
 }
-
 impl TypeConversion for ComponentInterest_Query {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             constraint: <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::from_type(&input.get_object(1))?,
-            
             full_snapshot_result: if input.count::<SchemaBool>(2) > 0 { Some(input.get::<SchemaBool>(2)) } else { None },
-            
             result_component_id: input.get_list::<SchemaUint32>(3),
-            
             frequency: if input.count::<SchemaFloat>(4) > 0 { Some(input.get::<SchemaFloat>(4)) } else { None },
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::to_type(&&input.constraint, &mut output.add_object(1))?;
-        
         if let Some(data) = &input.full_snapshot_result { output.add::<SchemaBool>(2, data); };
-        
         output.add_list::<SchemaUint32>(3, &&input.result_component_id[..]);
-        
         if let Some(data) = &input.frequency { output.add::<SchemaFloat>(4, data); };
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_QueryConstraint {
@@ -833,157 +755,102 @@ pub struct ComponentInterest_QueryConstraint {
     pub and_constraint: Vec<generated::improbable::ComponentInterest_QueryConstraint>,
     pub or_constraint: Vec<generated::improbable::ComponentInterest_QueryConstraint>,
 }
-
 impl TypeConversion for ComponentInterest_QueryConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             sphere_constraint: if input.object_count(1) > 0 { Some(<generated::improbable::ComponentInterest_SphereConstraint as TypeConversion>::from_type(&input.get_object(1))?) } else { None },
-            
             cylinder_constraint: if input.object_count(2) > 0 { Some(<generated::improbable::ComponentInterest_CylinderConstraint as TypeConversion>::from_type(&input.get_object(2))?) } else { None },
-            
             box_constraint: if input.object_count(3) > 0 { Some(<generated::improbable::ComponentInterest_BoxConstraint as TypeConversion>::from_type(&input.get_object(3))?) } else { None },
-            
             relative_sphere_constraint: if input.object_count(4) > 0 { Some(<generated::improbable::ComponentInterest_RelativeSphereConstraint as TypeConversion>::from_type(&input.get_object(4))?) } else { None },
-            
             relative_cylinder_constraint: if input.object_count(5) > 0 { Some(<generated::improbable::ComponentInterest_RelativeCylinderConstraint as TypeConversion>::from_type(&input.get_object(5))?) } else { None },
-            
             relative_box_constraint: if input.object_count(6) > 0 { Some(<generated::improbable::ComponentInterest_RelativeBoxConstraint as TypeConversion>::from_type(&input.get_object(6))?) } else { None },
-            
             entity_id_constraint: if input.count::<SchemaInt64>(7) > 0 { Some(input.get::<SchemaInt64>(7)) } else { None },
-            
             component_constraint: if input.count::<SchemaUint32>(8) > 0 { Some(input.get::<SchemaUint32>(8)) } else { None },
-            
             and_constraint: { let size = input.object_count(9); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::from_type(&input.index_object(9, i))?); } l },
-            
             or_constraint: { let size = input.object_count(10); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::from_type(&input.index_object(10, i))?); } l },
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         if let Some(ref data) = &input.sphere_constraint { <generated::improbable::ComponentInterest_SphereConstraint as TypeConversion>::to_type(&data, &mut output.add_object(1))?; };
-        
         if let Some(ref data) = &input.cylinder_constraint { <generated::improbable::ComponentInterest_CylinderConstraint as TypeConversion>::to_type(&data, &mut output.add_object(2))?; };
-        
         if let Some(ref data) = &input.box_constraint { <generated::improbable::ComponentInterest_BoxConstraint as TypeConversion>::to_type(&data, &mut output.add_object(3))?; };
-        
         if let Some(ref data) = &input.relative_sphere_constraint { <generated::improbable::ComponentInterest_RelativeSphereConstraint as TypeConversion>::to_type(&data, &mut output.add_object(4))?; };
-        
         if let Some(ref data) = &input.relative_cylinder_constraint { <generated::improbable::ComponentInterest_RelativeCylinderConstraint as TypeConversion>::to_type(&data, &mut output.add_object(5))?; };
-        
         if let Some(ref data) = &input.relative_box_constraint { <generated::improbable::ComponentInterest_RelativeBoxConstraint as TypeConversion>::to_type(&data, &mut output.add_object(6))?; };
-        
         if let Some(data) = &input.entity_id_constraint { output.add::<SchemaInt64>(7, data); };
-        
         if let Some(data) = &input.component_constraint { output.add::<SchemaUint32>(8, data); };
-        
         for element in (&input.and_constraint).iter() { <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::to_type(&element, &mut output.add_object(9))?; };
-        
         for element in (&input.or_constraint).iter() { <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::to_type(&element, &mut output.add_object(10))?; };
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_RelativeBoxConstraint {
     pub edge_length: generated::improbable::EdgeLength,
 }
-
 impl TypeConversion for ComponentInterest_RelativeBoxConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             edge_length: <generated::improbable::EdgeLength as TypeConversion>::from_type(&input.get_object(1))?,
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         <generated::improbable::EdgeLength as TypeConversion>::to_type(&&input.edge_length, &mut output.add_object(1))?;
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_RelativeCylinderConstraint {
     pub radius: f64,
 }
-
 impl TypeConversion for ComponentInterest_RelativeCylinderConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             radius: input.get::<SchemaDouble>(1),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaDouble>(1, &input.radius);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_RelativeSphereConstraint {
     pub radius: f64,
 }
-
 impl TypeConversion for ComponentInterest_RelativeSphereConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             radius: input.get::<SchemaDouble>(1),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaDouble>(1, &input.radius);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct ComponentInterest_SphereConstraint {
     pub center: generated::improbable::Coordinates,
     pub radius: f64,
 }
-
 impl TypeConversion for ComponentInterest_SphereConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             center: <generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?,
-            
             radius: input.get::<SchemaDouble>(2),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         <generated::improbable::Coordinates as TypeConversion>::to_type(&&input.center, &mut output.add_object(1))?;
-        
         output.add::<SchemaDouble>(2, &input.radius);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct Coordinates {
@@ -991,32 +858,21 @@ pub struct Coordinates {
     pub y: f64,
     pub z: f64,
 }
-
 impl TypeConversion for Coordinates {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             x: input.get::<SchemaDouble>(1),
-            
             y: input.get::<SchemaDouble>(2),
-            
             z: input.get::<SchemaDouble>(3),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaDouble>(1, &input.x);
-        
         output.add::<SchemaDouble>(2, &input.y);
-        
         output.add::<SchemaDouble>(3, &input.z);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct EdgeLength {
@@ -1024,77 +880,53 @@ pub struct EdgeLength {
     pub y: f64,
     pub z: f64,
 }
-
 impl TypeConversion for EdgeLength {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             x: input.get::<SchemaDouble>(1),
-            
             y: input.get::<SchemaDouble>(2),
-            
             z: input.get::<SchemaDouble>(3),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaDouble>(1, &input.x);
-        
         output.add::<SchemaDouble>(2, &input.y);
-        
         output.add::<SchemaDouble>(3, &input.z);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct WorkerAttributeSet {
     pub attribute: Vec<String>,
 }
-
 impl TypeConversion for WorkerAttributeSet {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             attribute: input.get_list::<SchemaString>(1),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add_list::<SchemaString>(1, &&input.attribute[..]);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct WorkerRequirementSet {
     pub attribute_set: Vec<generated::improbable::WorkerAttributeSet>,
 }
-
 impl TypeConversion for WorkerRequirementSet {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             attribute_set: { let size = input.object_count(1); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::WorkerAttributeSet as TypeConversion>::from_type(&input.index_object(1, i))?); } l },
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         for element in (&input.attribute_set).iter() { <generated::improbable::WorkerAttributeSet as TypeConversion>::to_type(&element, &mut output.add_object(1))?; };
-        
         Ok(())
     }
 }
-
 
 /* Components. */ 
 #[derive(Debug, Clone)]
@@ -1186,7 +1018,7 @@ impl Component for EntityAcl {
         }
     }
 
-    fn to_data(data: &generated::improbable::EntityAcl) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::EntityAcl) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::EntityAcl as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -1308,7 +1140,7 @@ impl Component for Interest {
         }
     }
 
-    fn to_data(data: &generated::improbable::Interest) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::Interest) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::Interest as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -1430,7 +1262,7 @@ impl Component for Metadata {
         }
     }
 
-    fn to_data(data: &generated::improbable::Metadata) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::Metadata) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::Metadata as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -1542,7 +1374,7 @@ impl Component for Persistence {
         }
     }
 
-    fn to_data(data: &generated::improbable::Persistence) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::Persistence) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::Persistence as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -1664,7 +1496,7 @@ impl Component for Position {
         }
     }
 
-    fn to_data(data: &generated::improbable::Position) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::Position) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::Position as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -1751,79 +1583,54 @@ impl Connection_ConnectionStatus {
     }
 }
 
-
-
 /* Types. */
-
-
 #[derive(Debug, Clone)]
 pub struct Connection {
     pub status: generated::improbable::restricted::Connection_ConnectionStatus,
     pub data_latency_ms: u32,
     pub connected_since_utc: u64,
 }
-
 impl TypeConversion for Connection {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             status: From::from(input.get::<SchemaEnum>(1)),
-            
             data_latency_ms: input.get::<SchemaUint32>(2),
-            
             connected_since_utc: input.get::<SchemaUint64>(3),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaEnum>(1, &&input.status.as_u32());
-        
         output.add::<SchemaUint32>(2, &input.data_latency_ms);
-        
         output.add::<SchemaUint64>(3, &input.connected_since_utc);
-        
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct DisconnectRequest {
 }
-
 impl TypeConversion for DisconnectRequest {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct DisconnectResponse {
 }
-
 impl TypeConversion for DisconnectResponse {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         Ok(())
     }
 }
-
-
 
 #[derive(Debug, Clone)]
 pub struct PlayerIdentity {
@@ -1831,31 +1638,21 @@ pub struct PlayerIdentity {
     pub provider: String,
     pub metadata: Vec<u8>,
 }
-
 impl TypeConversion for PlayerIdentity {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            
             player_identifier: input.get::<SchemaString>(1),
-            
             provider: input.get::<SchemaString>(2),
-            
             metadata: input.get::<SchemaBytes>(3),
-            
         })
     }
-
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaString>(1, &input.player_identifier);
-        
         output.add::<SchemaString>(2, &input.provider);
-        
         output.add::<SchemaBytes>(3, &input.metadata);
-        
         Ok(())
     }
 }
-
 
 /* Components. */ 
 #[derive(Debug, Clone)]
@@ -1937,7 +1734,7 @@ impl Component for PlayerClient {
         }
     }
 
-    fn to_data(data: &generated::improbable::restricted::PlayerClient) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::restricted::PlayerClient) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::restricted::PlayerClient as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -2049,7 +1846,7 @@ impl Component for System {
         }
     }
 
-    fn to_data(data: &generated::improbable::restricted::System) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::restricted::System) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::restricted::System as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)
@@ -2201,7 +1998,7 @@ impl Component for Worker {
         }
     }
 
-    fn to_data(data: &generated::improbable::restricted::Worker) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &generated::improbable::restricted::Worker) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <generated::improbable::restricted::Worker as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -109,7 +109,7 @@ fn logic_loop(c: &mut WorkerConnection) {
                         let entity_state = world
                             .get_mut(&add_component.entity_id)
                             .expect("Entity wasn't present in local world");
-                        entity_state.rotate = Some(rotate.clone());
+                        entity_state.rotate = Some(rotate.into_owned());
                     }
                     id => println!("Received unknown component: {}", id),
                 },

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -170,7 +170,7 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
         }
     }
 
-    fn to_data(data: &<#= self.rust_fqname(&component.qualified_name) #>) -> Result<SchemaComponentData, String> {
+    fn to_data(data: &<#= self.rust_fqname(&component.qualified_name) #>) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
         <<#= self.rust_fqname(&component.qualified_name) #> as TypeConversion>::to_type(data, &mut serialized_data.fields_mut())?;
         Ok(serialized_data)

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -1,5 +1,7 @@
-use crate::worker::component::{self, Component, ComponentId, DATABASE};
-use crate::worker::schema::SchemaComponentData;
+use crate::worker::{
+    component::{self, Component, ComponentId, DATABASE},
+    schema::*,
+};
 use spatialos_sdk_sys::worker::{Schema_DestroyComponentData, Worker_ComponentData, Worker_Entity};
 use std::collections::HashMap;
 use std::ptr;
@@ -75,11 +77,10 @@ impl Entity {
     pub(crate) unsafe fn add_serialized(
         &mut self,
         component_id: ComponentId,
-        component: SchemaComponentData,
+        component: Owned<SchemaComponentData>,
     ) -> Result<(), String> {
         let vtable = DATABASE.get_vtable(component_id).unwrap();
         let deserialize_func = vtable.component_data_deserialize.unwrap_or_else(|| {
-            Schema_DestroyComponentData(component.internal);
             panic!(
                 "No component_data_deserialize method defined for {}",
                 component_id

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -2,7 +2,7 @@ use crate::worker::{
     component::{self, Component, ComponentId, DATABASE},
     schema::*,
 };
-use spatialos_sdk_sys::worker::{Schema_DestroyComponentData, Worker_ComponentData, Worker_Entity};
+use spatialos_sdk_sys::worker::{Worker_ComponentData, Worker_Entity};
 use std::collections::HashMap;
 use std::ptr;
 use std::slice;
@@ -95,10 +95,9 @@ impl Entity {
         let deserialize_result = deserialize_func(
             component_id,
             ptr::null_mut(),
-            component.internal,
+            component.as_ptr(),
             handle_out_ptr,
         );
-        Schema_DestroyComponentData(component.internal);
 
         match deserialize_result {
             1 => {},

--- a/spatialos-sdk/src/worker/entity_builder.rs
+++ b/spatialos-sdk/src/worker/entity_builder.rs
@@ -1,9 +1,4 @@
-use crate::worker::{
-    component::Component,
-    component::ComponentId,
-    entity::Entity,
-    schema::{SchemaComponentData, SchemaDouble, SchemaString, SchemaUint32},
-};
+use crate::worker::{component::Component, component::ComponentId, entity::Entity, schema::*};
 use std::collections::{HashMap, HashSet};
 
 const ENTITY_ACL_COMPONENT_ID: ComponentId = 50;
@@ -116,7 +111,7 @@ impl EntityBuilder {
     //
     // If this invariant is broken, then the EntityBuilder is broken. Should we assert against this
     // before we call `entity.add_serialized`?
-    fn serialize_position(&self) -> SchemaComponentData {
+    fn serialize_position(&self) -> Owned<SchemaComponentData> {
         let mut position_schema = SchemaComponentData::new();
         let position_fields = position_schema.fields_mut();
 
@@ -128,7 +123,7 @@ impl EntityBuilder {
         position_schema
     }
 
-    fn serialize_acl(&self) -> SchemaComponentData {
+    fn serialize_acl(&self) -> Owned<SchemaComponentData> {
         let mut acl_schema = SchemaComponentData::new();
         let acl_fields = acl_schema.fields_mut();
 
@@ -151,7 +146,7 @@ impl EntityBuilder {
         acl_schema
     }
 
-    fn serialize_metadata(&self) -> SchemaComponentData {
+    fn serialize_metadata(&self) -> Owned<SchemaComponentData> {
         let mut metadata_schema = SchemaComponentData::new();
         let metadata_fields = metadata_schema.fields_mut();
         metadata_fields.add::<SchemaString>(1, self.metadata.as_ref().unwrap());
@@ -159,7 +154,7 @@ impl EntityBuilder {
         metadata_schema
     }
 
-    fn serialize_persistence(&self) -> SchemaComponentData {
+    fn serialize_persistence(&self) -> Owned<SchemaComponentData> {
         SchemaComponentData::new()
     }
 }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -3,10 +3,16 @@ mod command_response;
 mod component_data;
 mod component_update;
 mod object;
+mod owned;
 mod primitives;
 
 pub use self::{
-    command_request::*, command_response::*, component_data::*, component_update::*, object::*,
+    command_request::*,
+    command_response::*,
+    component_data::*,
+    component_update::*,
+    object::*,
+    owned::{Ownable, Owned},
     primitives::*,
 };
 

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -3,17 +3,13 @@ mod command_response;
 mod component_data;
 mod component_update;
 mod object;
-mod owned;
 mod primitives;
 
+pub mod owned;
+
 pub use self::{
-    command_request::*,
-    command_response::*,
-    component_data::*,
-    component_update::*,
-    object::*,
-    owned::{Ownable, Owned},
-    primitives::*,
+    command_request::*, command_response::*, component_data::*, component_update::*, object::*,
+    owned::Owned, primitives::*,
 };
 
 pub type FieldId = u32;

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -31,10 +31,6 @@ impl SchemaComponentData {
         &*(raw as *mut _)
     }
 
-    pub(crate) unsafe fn from_raw_mut<'a>(raw: *mut Schema_ComponentData) -> &'a mut Self {
-        &mut *(raw as *mut _)
-    }
-
     pub(crate) fn as_ptr(&self) -> *mut Schema_ComponentData {
         self as *const _ as *mut _
     }

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -55,5 +55,11 @@ impl OwnableImpl for SchemaComponentData {
     }
 }
 
+// SAFETY: It should be safe to send a `SchemaComponentData` between threads, so long as
+// it's only ever accessed from one thread at a time. It has unsynchronized internal
+// mutability (when getting an object field, it will automatically add a new object
+// if one doesn't already exist), so it cannot be `Sync`.
+unsafe impl Send for SchemaComponentData {}
+
 assert_impl_all!(SchemaComponentData: Send);
 assert_not_impl_any!(SchemaComponentData: Sync);

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -1,29 +1,59 @@
-use crate::worker::schema::SchemaObject;
+use crate::worker::schema::{owned::*, SchemaObject};
 use spatialos_sdk_sys::worker::*;
+use static_assertions::*;
+use std::marker::PhantomData;
 
+/// Serialized schema data for a component, owned by the Rust SDK.
+///
+/// For maximum efficiency, the serialized data may borrow data from the component
+/// used to create an `OwnedComponentData` instance. The lifetime parameter
+/// tracks this borrow, such that an `OwnedComponentData` cannot outlive the
+/// data it borrows.
 #[derive(Debug)]
-pub struct SchemaComponentData {
-    pub(crate) internal: *mut Schema_ComponentData,
-}
+pub struct SchemaComponentData(PhantomData<*mut Schema_ComponentData>);
 
 impl SchemaComponentData {
-    pub fn new() -> SchemaComponentData {
-        SchemaComponentData {
-            internal: unsafe { Schema_CreateComponentData() },
-        }
+    pub fn new() -> Owned<SchemaComponentData> {
+        unsafe { Owned::new(Schema_CreateComponentData()) }
     }
 
     pub fn fields(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetComponentDataFields(self.internal)) }
+        unsafe { SchemaObject::from_raw(Schema_GetComponentDataFields(self.as_ptr())) }
     }
 
     pub fn fields_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentDataFields(self.internal)) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentDataFields(self.as_ptr())) }
+    }
+
+    // Methods for raw pointer conversion.
+    // -----------------------------------
+
+    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_ComponentData) -> &'a Self {
+        &*(raw as *mut _)
+    }
+
+    pub(crate) unsafe fn from_raw_mut<'a>(raw: *mut Schema_ComponentData) -> &'a mut Self {
+        &mut *(raw as *mut _)
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut Schema_ComponentData {
+        self as *const _ as *mut _
     }
 }
 
-impl Default for SchemaComponentData {
+impl Default for Owned<SchemaComponentData> {
     fn default() -> Self {
-        Self::new()
+        SchemaComponentData::new()
     }
 }
+
+impl OwnableImpl for SchemaComponentData {
+    type Raw = Schema_ComponentData;
+
+    unsafe fn destroy(inst: *mut Self::Raw) {
+        Schema_DestroyComponentData(inst);
+    }
+}
+
+assert_impl_all!(SchemaComponentData: Send);
+assert_not_impl_any!(SchemaComponentData: Sync);

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -1,6 +1,5 @@
 use crate::worker::schema::{owned::*, SchemaObject};
 use spatialos_sdk_sys::worker::*;
-use static_assertions::*;
 use std::marker::PhantomData;
 
 /// Serialized schema data for a component, owned by the Rust SDK.
@@ -61,5 +60,11 @@ impl OwnableImpl for SchemaComponentData {
 // if one doesn't already exist), so it cannot be `Sync`.
 unsafe impl Send for SchemaComponentData {}
 
-assert_impl_all!(SchemaComponentData: Send);
-assert_not_impl_any!(SchemaComponentData: Sync);
+#[cfg(test)]
+mod test {
+    use super::SchemaComponentData;
+    use static_assertions::*;
+
+    assert_impl_all!(SchemaComponentData: Send);
+    assert_not_impl_any!(SchemaComponentData: Sync);
+}

--- a/spatialos-sdk/src/worker/schema/owned.rs
+++ b/spatialos-sdk/src/worker/schema/owned.rs
@@ -1,0 +1,86 @@
+//! A pointer type for owned schema data types.
+//!
+//! When you own an instance of some schema data type, such as
+//! [`ComponentData`], the [`Owned`] smart pointer handles automatically
+//! destroying the object when it goes out of scope. In this way, it behaves like
+//! [`Box`] for SpatialOS-specific types.
+//!
+//! You cannot directly create an `Owned<T>`, instead each type that can be owned
+//! directly will provide its own type-appropriate constructors. See
+//! [`ComponentData::new`] for an example.
+//!
+//! [`ComponentData`]: ../struct.ComponentData.html
+//! [`ComponentData::new`]: ../struct.ComponentData.html#method.new
+//! [`Owned`]: struct.Owned.html
+//! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
+
+use std::{
+    mem,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
+
+pub(crate) use self::private::OwnableImpl;
+
+pub(crate) mod private {
+    /// Private imlementation of the `Ownable` trait. Used to hide implementation
+    /// details and seal the trait from downstream implementations.
+    pub trait OwnableImpl {
+        type Raw;
+        unsafe fn destroy(me: *mut Self::Raw);
+    }
+}
+
+pub trait Ownable: OwnableImpl {}
+
+impl<T> Ownable for T where T: OwnableImpl {}
+
+/// Like [`Box`], but for SpatialOS schema types.
+///
+/// See the [module-level documentation](index.html) for more.
+///
+/// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
+#[derive(Debug)]
+pub struct Owned<T: Ownable>(NonNull<T::Raw>);
+
+impl<T: Ownable> Owned<T> {
+    pub(crate) unsafe fn new(raw: *mut T::Raw) -> Self {
+        Self(NonNull::new(raw).expect("Cannot create `Owned` from null pointer"))
+    }
+
+    /// Converts an owned piece of schema data back into the raw type without dropping it.
+    ///
+    /// This transfers ownership of the data to the caller, so the caller needs to
+    /// ensure that the appropriate steps are taken to free the data. If the raw data is
+    /// passed to the C API, the C SDK will take ownership of the data and will free it
+    /// when it's done.
+    pub(crate) fn into_raw(self) -> *mut T::Raw {
+        let raw = self.0.as_ptr();
+        mem::forget(self);
+        raw
+    }
+}
+
+impl<T: Ownable> Drop for Owned<T> {
+    fn drop(&mut self) {
+        unsafe {
+            T::destroy(self.0.as_ptr());
+        }
+    }
+}
+
+impl<T: Ownable> Deref for Owned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.0.cast().as_ptr() }
+    }
+}
+
+impl<T: Ownable> DerefMut for Owned<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.0.cast().as_ptr() }
+    }
+}
+
+unsafe impl<T: Ownable + Send> Send for Owned<T> {}


### PR DESCRIPTION
> Part of #121 

Further work re-implementing the work from #101, this time patching up the soundness holes in `SchemaComponentData`. This is very similar to the changes in #127, with the addition step of adding the `Owned` smart pointer type.

`Owned` is like `Box`, but used only for the schema data objects. This abstraction is necessary because even when we "own" a `Schema_ComponentData`, we only have a pointer and not the struct itself. As such, we can't represent it in Rust as a struct on its own or the ownership interactions will (to use a technical term) get all fucky. In this case, we need to create our own smart pointer type instead of using `Box` directly since each schema data object objects has its own deallocation function in the C API.

As a helper for `Owned`, we also define the `Ownable` and `OwnableImpl` traits, with `Ownable` just being a public-facing facade that we can use as a trait bound in the public API for `Owned`. The `OwnableImpl` trait contains the real logic, i.e. an associated type for the raw pointer representation of the schema data object and a function for freeing the object when dropped.

I've also removed the `ComponentData` helper type from the `component::internal` module and replaced it with the `ComponentDataRef` type. In doing so, I've made a couple of tweaks to how incoming schema data (from worker ops) is handled:

* Use an `Option<NonNull>` to represent the raw user handle. This enforces stricter null checking and allows us to do a bit less raw pointer manipulation.
* Return a `Cow` when attempting to get the deserialized component data, automatically deserializing the schema object if the user handle is null (i.e. if vtable serialization is disabled for that type).

This is the pattern I took for #101, and I'll continue to convert the remaining schema objects types this way if it looks good to yall 😁 