### PR TITLE
Remaining soundness fixes

### DIFF
--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -210,7 +210,7 @@ impl Component for EntityIdTest {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::example::EntityIdTestUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::example::EntityIdTestUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::example::EntityIdTestUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -332,7 +332,7 @@ impl Component for EnumTestComponent {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::example::EnumTestComponentUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::example::EnumTestComponentUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::example::EnumTestComponentUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -464,7 +464,7 @@ impl Component for Example {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::example::ExampleUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::example::ExampleUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::example::ExampleUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -614,7 +614,7 @@ impl Component for Rotate {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::example::RotateUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::example::RotateUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::example::RotateUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -1024,7 +1024,7 @@ impl Component for EntityAcl {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::EntityAclUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::EntityAclUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::EntityAclUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -1146,7 +1146,7 @@ impl Component for Interest {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::InterestUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::InterestUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::InterestUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -1268,7 +1268,7 @@ impl Component for Metadata {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::MetadataUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::MetadataUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::MetadataUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -1380,7 +1380,7 @@ impl Component for Persistence {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::PersistenceUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::PersistenceUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::PersistenceUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -1502,7 +1502,7 @@ impl Component for Position {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::PositionUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::PositionUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::PositionUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -1740,7 +1740,7 @@ impl Component for PlayerClient {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::restricted::PlayerClientUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::restricted::PlayerClientUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::restricted::PlayerClientUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -1852,7 +1852,7 @@ impl Component for System {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::restricted::SystemUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::restricted::SystemUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::restricted::SystemUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)
@@ -2004,7 +2004,7 @@ impl Component for Worker {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &generated::improbable::restricted::WorkerUpdate) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &generated::improbable::restricted::WorkerUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <generated::improbable::restricted::WorkerUpdate as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -216,7 +216,7 @@ impl Component for EntityIdTest {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::example::EntityIdTestCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::example::EntityIdTestCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -224,7 +224,7 @@ impl Component for EntityIdTest {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::example::EntityIdTestCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::example::EntityIdTestCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -338,7 +338,7 @@ impl Component for EnumTestComponent {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::example::EnumTestComponentCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::example::EnumTestComponentCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -346,7 +346,7 @@ impl Component for EnumTestComponent {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::example::EnumTestComponentCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::example::EnumTestComponentCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -470,7 +470,7 @@ impl Component for Example {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::example::ExampleCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::example::ExampleCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             ExampleCommandRequest::TestCommand(ref data) => {
@@ -481,7 +481,7 @@ impl Component for Example {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::example::ExampleCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::example::ExampleCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             ExampleCommandResponse::TestCommand(ref data) => {
@@ -620,7 +620,7 @@ impl Component for Rotate {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::example::RotateCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::example::RotateCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -628,7 +628,7 @@ impl Component for Rotate {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::example::RotateCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::example::RotateCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -1030,7 +1030,7 @@ impl Component for EntityAcl {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::EntityAclCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::EntityAclCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -1038,7 +1038,7 @@ impl Component for EntityAcl {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::EntityAclCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::EntityAclCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -1152,7 +1152,7 @@ impl Component for Interest {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::InterestCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::InterestCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -1160,7 +1160,7 @@ impl Component for Interest {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::InterestCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::InterestCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -1274,7 +1274,7 @@ impl Component for Metadata {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::MetadataCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::MetadataCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -1282,7 +1282,7 @@ impl Component for Metadata {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::MetadataCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::MetadataCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -1386,7 +1386,7 @@ impl Component for Persistence {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::PersistenceCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::PersistenceCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -1394,7 +1394,7 @@ impl Component for Persistence {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::PersistenceCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::PersistenceCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -1508,7 +1508,7 @@ impl Component for Position {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::PositionCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::PositionCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -1516,7 +1516,7 @@ impl Component for Position {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::PositionCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::PositionCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -1746,7 +1746,7 @@ impl Component for PlayerClient {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::restricted::PlayerClientCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::restricted::PlayerClientCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -1754,7 +1754,7 @@ impl Component for PlayerClient {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::restricted::PlayerClientCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::restricted::PlayerClientCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -1858,7 +1858,7 @@ impl Component for System {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::restricted::SystemCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::restricted::SystemCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             _ => unreachable!()
@@ -1866,7 +1866,7 @@ impl Component for System {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::restricted::SystemCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::restricted::SystemCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             _ => unreachable!()
@@ -2010,7 +2010,7 @@ impl Component for Worker {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &generated::improbable::restricted::WorkerCommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &generated::improbable::restricted::WorkerCommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             WorkerCommandRequest::Disconnect(ref data) => {
@@ -2021,7 +2021,7 @@ impl Component for Worker {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &generated::improbable::restricted::WorkerCommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &generated::improbable::restricted::WorkerCommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             WorkerCommandResponse::Disconnect(ref data) => {

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -138,7 +138,7 @@ fn logic_loop(c: &mut WorkerConnection) {
                         let component_update = update.get::<example::Rotate>().unwrap();
                         let state = world.get_mut(&update.entity_id).unwrap();
                         let rotate = state.rotate.as_mut().unwrap();
-                        rotate.merge(component_update.clone());
+                        rotate.merge(component_update.into_owned());
                     }
                     id => println!("Received unknown component: {}", id),
                 },

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -176,7 +176,7 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
         Ok(serialized_data)
     }
 
-    fn to_update(update: &<#= self.rust_fqname(&component.qualified_name) #>Update) -> Result<SchemaComponentUpdate, String> {
+    fn to_update(update: &<#= self.rust_fqname(&component.qualified_name) #>Update) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
         <<#= self.rust_fqname(&component.qualified_name) #>Update as TypeConversion>::to_type(update, &mut serialized_update.fields_mut())?;
         Ok(serialized_update)

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -182,7 +182,7 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
         Ok(serialized_update)
     }
 
-    fn to_request(request: &<#= self.rust_fqname(&component.qualified_name) #>CommandRequest) -> Result<SchemaCommandRequest, String> {
+    fn to_request(request: &<#= self.rust_fqname(&component.qualified_name) #>CommandRequest) -> Result<Owned<SchemaCommandRequest>, String> {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {<#
             for command in &component.commands {
@@ -195,7 +195,7 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
         Ok(serialized_request)
     }
 
-    fn to_response(response: &<#= self.rust_fqname(&component.qualified_name) #>CommandResponse) -> Result<SchemaCommandResponse, String> {
+    fn to_response(response: &<#= self.rust_fqname(&component.qualified_name) #>CommandResponse) -> Result<Owned<SchemaCommandResponse>, String> {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {<#
             for command in &component.commands {

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -52,10 +52,10 @@ where
 
     fn to_data(data: &Self) -> Result<Owned<SchemaComponentData>, String>;
     fn to_update(update: &Self::Update) -> Result<Owned<SchemaComponentUpdate>, String>;
-    fn to_request(request: &Self::CommandRequest) -> Result<schema::SchemaCommandRequest, String>;
+    fn to_request(request: &Self::CommandRequest) -> Result<Owned<SchemaCommandRequest>, String>;
     fn to_response(
         response: &Self::CommandResponse,
-    ) -> Result<schema::SchemaCommandResponse, String>;
+    ) -> Result<Owned<SchemaCommandResponse>, String>;
 
     fn get_request_command_index(request: &Self::CommandRequest) -> u32;
     fn get_response_command_index(response: &Self::CommandResponse) -> u32;
@@ -161,9 +161,9 @@ impl<'a> ComponentDataRef<'a> {
 
 #[derive(Debug)]
 pub(crate) struct ComponentUpdateRef<'a> {
-    pub component_id: ComponentId,
-    pub schema_type: &'a SchemaComponentUpdate,
-    pub user_handle: Option<NonNull<Worker_ComponentUpdateHandle>>,
+    component_id: ComponentId,
+    schema_type: &'a SchemaComponentUpdate,
+    user_handle: Option<NonNull<Worker_ComponentUpdateHandle>>,
 }
 
 impl<'a> ComponentUpdateRef<'a> {
@@ -179,7 +179,7 @@ impl<'a> ComponentUpdateRef<'a> {
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
-    pub fn get<C>(&self) -> Option<Cow<'_, C::Update>>
+    pub(crate) fn get<C>(&self) -> Option<Cow<'_, C::Update>>
     where
         C: Component,
         C::Update: TypeConversion + Clone,
@@ -199,65 +199,86 @@ impl<'a> ComponentUpdateRef<'a> {
     }
 }
 
-// Internal untyped component data objects.
-pub(crate) mod internal {
-    use crate::worker::schema::*;
-    use spatialos_sdk_sys::worker::*;
-    use std::marker::PhantomData;
+#[derive(Debug)]
+pub(crate) struct CommandRequestRef<'a> {
+    component_id: ComponentId,
+    command_index: FieldId,
+    schema_type: &'a SchemaCommandRequest,
+    user_handle: Option<NonNull<Worker_CommandRequestHandle>>,
+}
 
-    use crate::worker::component::ComponentId;
-
-    #[derive(Debug)]
-    pub struct CommandRequest<'a> {
-        pub component_id: ComponentId,
-        pub command_index: FieldId,
-        pub schema_type: SchemaCommandRequest,
-        pub user_handle: *const Worker_CommandRequestHandle,
-
-        // NOTE: `user_handle` is borrowing data owned by the parent object, but it's a
-        // type-erased pointer that may be null, so we just mark that we're borrowing
-        // *something*.
-        pub _marker: PhantomData<&'a ()>,
-    }
-
-    impl<'a> From<&'a Worker_CommandRequest> for CommandRequest<'a> {
-        fn from(request: &Worker_CommandRequest) -> Self {
-            CommandRequest {
-                component_id: request.component_id,
-                command_index: request.command_index,
-                schema_type: SchemaCommandRequest {
-                    internal: request.schema_type,
-                },
-                user_handle: request.user_handle,
-                _marker: PhantomData,
-            }
+impl<'a> CommandRequestRef<'a> {
+    pub(crate) unsafe fn from_raw(request: &Worker_CommandRequest) -> Self {
+        Self {
+            component_id: request.component_id,
+            command_index: request.command_index,
+            schema_type: SchemaCommandRequest::from_raw(request.schema_type),
+            user_handle: NonNull::new(request.user_handle),
         }
     }
 
-    #[derive(Debug)]
-    pub struct CommandResponse<'a> {
-        pub component_id: ComponentId,
-        pub command_index: FieldId,
-        pub schema_type: SchemaCommandResponse,
-        pub user_handle: *const Worker_CommandResponseHandle,
+    // NOTE: We manually declare that the update impl `TypeConversion` and `Clone`
+    // here, but in practice this will always be true for all component types. Future
+    // iterations should clean this up such that the `Component` trait can imply these
+    // other bounds automatically (i.e. by making them super traits of `Component`).
+    pub(crate) fn get<C>(&self) -> Option<Cow<'_, C::CommandRequest>>
+    where
+        C: Component,
+        C::CommandRequest: TypeConversion + Clone,
+    {
+        if C::ID != self.component_id {
+            return None;
+        }
 
-        // NOTE: `user_handle` is borrowing data owned by the parent object, but it's a
-        // type-erased pointer that may be null, so we just mark that we're borrowing
-        // *something*.
-        pub _marker: PhantomData<&'a ()>,
+        if let Some(user_handle) = &self.user_handle {
+            let component = unsafe { &*user_handle.cast().as_ptr() };
+            Some(Cow::Borrowed(component))
+        } else {
+            TypeConversion::from_type(self.schema_type.object())
+                .ok()
+                .map(Cow::Owned)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CommandResponseRef<'a> {
+    component_id: ComponentId,
+    command_index: FieldId,
+    schema_type: &'a SchemaCommandResponse,
+    user_handle: Option<NonNull<Worker_CommandResponseHandle>>,
+}
+
+impl<'a> CommandResponseRef<'a> {
+    pub(crate) unsafe fn from_raw(response: &Worker_CommandResponse) -> Self {
+        Self {
+            component_id: response.component_id,
+            command_index: response.command_index,
+            schema_type: SchemaCommandResponse::from_raw(response.schema_type),
+            user_handle: NonNull::new(response.user_handle),
+        }
     }
 
-    impl<'a> From<&'a Worker_CommandResponse> for CommandResponse<'a> {
-        fn from(response: &Worker_CommandResponse) -> Self {
-            CommandResponse {
-                component_id: response.component_id,
-                command_index: response.command_index,
-                schema_type: SchemaCommandResponse {
-                    internal: response.schema_type,
-                },
-                user_handle: response.user_handle,
-                _marker: PhantomData,
-            }
+    // NOTE: We manually declare that the update impl `TypeConversion` and `Clone`
+    // here, but in practice this will always be true for all component types. Future
+    // iterations should clean this up such that the `Component` trait can imply these
+    // other bounds automatically (i.e. by making them super traits of `Component`).
+    pub fn get<C>(&self) -> Option<Cow<'_, C::CommandResponse>>
+    where
+        C: Component,
+        C::CommandResponse: TypeConversion + Clone,
+    {
+        if C::ID != self.component_id {
+            return None;
+        }
+
+        if let Some(user_handle) = &self.user_handle {
+            let component = unsafe { &*user_handle.cast().as_ptr() };
+            Some(Cow::Borrowed(component))
+        } else {
+            TypeConversion::from_type(self.schema_type.object())
+                .ok()
+                .map(Cow::Owned)
         }
     }
 }
@@ -475,7 +496,7 @@ unsafe extern "C" fn vtable_command_request_deserialize<C: Component>(
     request: *mut Schema_CommandRequest,
     handle_out: *mut *mut Worker_CommandRequestHandle,
 ) -> u8 {
-    let schema_request = schema::SchemaCommandRequest { internal: request };
+    let schema_request = SchemaCommandRequest::from_raw(request);
     let deserialized_result = C::from_request(command_index, &schema_request);
     if let Ok(deserialized_request) = deserialized_result {
         *handle_out = handle_allocate(deserialized_request);
@@ -495,7 +516,7 @@ unsafe extern "C" fn vtable_command_request_serialize<C: Component>(
     let data = &*(handle as *const _);
     let schema_result = C::to_request(data);
     if let Ok(schema_request) = schema_result {
-        *request = schema_request.internal;
+        *request = schema_request.into_raw();
     } else {
         *request = ptr::null_mut();
     }
@@ -526,7 +547,7 @@ unsafe extern "C" fn vtable_command_response_deserialize<C: Component>(
     response: *mut Schema_CommandResponse,
     handle_out: *mut *mut Worker_CommandRequestHandle,
 ) -> u8 {
-    let schema_response = schema::SchemaCommandResponse { internal: response };
+    let schema_response = SchemaCommandResponse::from_raw(response);
     let deserialized_result = C::from_response(command_index, &schema_response);
     if let Ok(deserialized_response) = deserialized_result {
         *handle_out = handle_allocate(deserialized_response);
@@ -546,7 +567,7 @@ unsafe extern "C" fn vtable_command_response_serialize<C: Component>(
     let data = &*(handle as *const _);
     let schema_result = C::to_response(data);
     if let Ok(schema_response) = schema_result {
-        *response = schema_response.internal;
+        *response = schema_response.into_raw();
     } else {
         *response = ptr::null_mut();
     }

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -6,7 +6,7 @@ use crate::worker::{
     entity::Entity,
     internal::utils::*,
     metrics::Metrics,
-    schema::{SchemaCommandRequest, SchemaCommandResponse, SchemaComponentUpdate},
+    schema::{SchemaCommandRequest, SchemaCommandResponse},
     {Authority, EntityId, LogLevel, RequestId},
 };
 use spatialos_sdk_sys::worker::*;

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -1,29 +1,54 @@
-use crate::worker::schema::SchemaObject;
+use crate::worker::schema::{owned::OwnableImpl, Owned, SchemaObject};
 use spatialos_sdk_sys::worker::*;
+use std::marker::PhantomData;
 
 #[derive(Debug)]
-pub struct SchemaCommandRequest {
-    pub(crate) internal: *mut Schema_CommandRequest,
-}
+pub struct SchemaCommandRequest(PhantomData<*mut Schema_CommandRequest>);
 
 impl SchemaCommandRequest {
-    pub fn new() -> SchemaCommandRequest {
-        SchemaCommandRequest {
-            internal: unsafe { Schema_CreateCommandRequest() },
-        }
+    pub fn new() -> Owned<SchemaCommandRequest> {
+        unsafe { Owned::new(Schema_CreateCommandRequest()) }
     }
 
     pub fn object(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetCommandRequestObject(self.internal)) }
+        unsafe { SchemaObject::from_raw(Schema_GetCommandRequestObject(self.as_ptr())) }
     }
 
     pub fn object_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandRequestObject(self.internal)) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandRequestObject(self.as_ptr())) }
+    }
+
+    // Methods for raw pointer conversion.
+    // -----------------------------------
+
+    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_CommandRequest) -> &'a Self {
+        &*(raw as *mut _)
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut Schema_CommandRequest {
+        self as *const _ as *mut _
     }
 }
 
-impl Default for SchemaCommandRequest {
-    fn default() -> Self {
-        Self::new()
+impl OwnableImpl for SchemaCommandRequest {
+    type Raw = Schema_CommandRequest;
+
+    unsafe fn destroy(me: *mut Self::Raw) {
+        Schema_DestroyCommandRequest(me);
     }
+}
+
+// SAFETY: It should be safe to send a `SchemaCommandRequest` between threads, so long as
+// it's only ever accessed from one thread at a time. It has unsynchronized internal
+// mutability (when getting an object field, it will automatically add a new object
+// if one doesn't already exist), so it cannot be `Sync`.
+unsafe impl Send for SchemaCommandRequest {}
+
+#[cfg(test)]
+mod tests {
+    use super::SchemaCommandRequest;
+    use static_assertions::*;
+
+    assert_impl_all!(SchemaCommandRequest: Send);
+    assert_not_impl_any!(SchemaCommandRequest: Sync);
 }

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -1,29 +1,54 @@
-use crate::worker::schema::SchemaObject;
+use crate::worker::schema::{owned::OwnableImpl, Owned, SchemaObject};
 use spatialos_sdk_sys::worker::*;
+use std::marker::PhantomData;
 
 #[derive(Debug)]
-pub struct SchemaCommandResponse {
-    pub(crate) internal: *mut Schema_CommandResponse,
-}
+pub struct SchemaCommandResponse(PhantomData<*mut Schema_CommandResponse>);
 
 impl SchemaCommandResponse {
-    pub fn new() -> SchemaCommandResponse {
-        SchemaCommandResponse {
-            internal: unsafe { Schema_CreateCommandResponse() },
-        }
+    pub fn new() -> Owned<SchemaCommandResponse> {
+        unsafe { Owned::new(Schema_CreateCommandResponse()) }
     }
 
     pub fn object(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetCommandResponseObject(self.internal)) }
+        unsafe { SchemaObject::from_raw(Schema_GetCommandResponseObject(self.as_ptr())) }
     }
 
     pub fn object_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandResponseObject(self.internal)) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandResponseObject(self.as_ptr())) }
+    }
+
+    // Methods for raw pointer conversion.
+    // -----------------------------------
+
+    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_CommandResponse) -> &'a Self {
+        &*(raw as *mut _)
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut Schema_CommandResponse {
+        self as *const _ as *mut _
     }
 }
 
-impl Default for SchemaCommandResponse {
-    fn default() -> Self {
-        Self::new()
+impl OwnableImpl for SchemaCommandResponse {
+    type Raw = Schema_CommandResponse;
+
+    unsafe fn destroy(me: *mut Self::Raw) {
+        Schema_DestroyCommandResponse(me);
     }
+}
+
+// SAFETY: It should be safe to send a `SchemaCommandResonse` between threads, so long as
+// it's only ever accessed from one thread at a time. It has unsynchronized internal
+// mutability (when getting an object field, it will automatically add a new object
+// if one doesn't already exist), so it cannot be `Sync`.
+unsafe impl Send for SchemaCommandResponse {}
+
+#[cfg(test)]
+mod tests {
+    use super::SchemaCommandResponse;
+    use static_assertions::*;
+
+    assert_impl_all!(SchemaCommandResponse: Send);
+    assert_not_impl_any!(SchemaCommandResponse: Sync);
 }

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -47,3 +47,18 @@ impl OwnableImpl for SchemaComponentUpdate {
         Schema_DestroyComponentUpdate(me);
     }
 }
+
+// SAFETY: It should be safe to send a `SchemaComponentUpdate` between threads, so long as
+// it's only ever accessed from one thread at a time. It has unsynchronized internal
+// mutability (when getting an object field, it will automatically add a new object
+// if one doesn't already exist), so it cannot be `Sync`.
+unsafe impl Send for SchemaComponentUpdate {}
+
+#[cfg(test)]
+mod tests {
+    use super::SchemaComponentUpdate;
+    use static_assertions::*;
+
+    assert_impl_all!(SchemaComponentUpdate: Send);
+    assert_not_impl_any!(SchemaComponentUpdate: Sync);
+}

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -1,39 +1,49 @@
-use crate::worker::schema::SchemaObject;
+use crate::worker::schema::{owned::OwnableImpl, Owned, SchemaObject};
 use spatialos_sdk_sys::worker::*;
+use std::marker::PhantomData;
 
 #[derive(Debug)]
-pub struct SchemaComponentUpdate {
-    pub(crate) internal: *mut Schema_ComponentUpdate,
-}
+pub struct SchemaComponentUpdate(PhantomData<*mut Schema_ComponentUpdate>);
 
 impl SchemaComponentUpdate {
-    pub fn new() -> SchemaComponentUpdate {
-        SchemaComponentUpdate {
-            internal: unsafe { Schema_CreateComponentUpdate() },
-        }
+    pub fn new() -> Owned<SchemaComponentUpdate> {
+        unsafe { Owned::new(Schema_CreateComponentUpdate()) }
     }
 
     pub fn fields(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateFields(self.internal)) }
+        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateFields(self.as_ptr())) }
     }
 
     pub fn fields_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateFields(self.internal)) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateFields(self.as_ptr())) }
     }
 
     pub fn events(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateEvents(self.internal)) }
+        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateEvents(self.as_ptr())) }
     }
 
     pub fn events_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateEvents(self.internal)) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateEvents(self.as_ptr())) }
     }
 
     // TODO: Cleared fields.
+
+    // Methods for raw pointer conversion.
+    // -----------------------------------
+
+    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_ComponentUpdate) -> &'a Self {
+        &*(raw as *mut _)
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut Schema_ComponentUpdate {
+        self as *const _ as *mut _
+    }
 }
 
-impl Default for SchemaComponentUpdate {
-    fn default() -> Self {
-        Self::new()
+impl OwnableImpl for SchemaComponentUpdate {
+    type Raw = Schema_ComponentUpdate;
+
+    unsafe fn destroy(me: *mut Self::Raw) {
+        Schema_DestroyComponentUpdate(me);
     }
 }


### PR DESCRIPTION
> Part of #121 

Fix soundness holes for remaining schema data objects (`SchemaComponentUpdate`, `SchemaCommandRequest`, and `SchemaCommandResponse`). This follows the same pattern as described in #101. I've also grouped up the remaining three because at this point all the changes are the same as the ones done in #127 and #128, it's just a lot of boilerplate changes at this point.