### PR TITLE
Unify handling of data pointer types

### DIFF
--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -77,7 +77,7 @@ impl Entity {
     pub(crate) unsafe fn add_serialized(
         &mut self,
         component_id: ComponentId,
-        component: Owned<SchemaComponentData>,
+        mut component: Owned<SchemaComponentData>,
     ) -> Result<(), String> {
         let vtable = DATABASE.get_vtable(component_id).unwrap();
         let deserialize_func = vtable.component_data_deserialize.unwrap_or_else(|| {
@@ -95,7 +95,7 @@ impl Entity {
         let deserialize_result = deserialize_func(
             component_id,
             ptr::null_mut(),
-            component.as_ptr(),
+            component.as_ptr_mut(),
             handle_out_ptr,
         );
 

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -12,6 +12,8 @@ pub use self::{
     owned::Owned, primitives::*,
 };
 
+pub(crate) use self::private::PointerType;
+
 pub type FieldId = u32;
 
 pub trait SchemaPrimitiveField {
@@ -30,5 +32,23 @@ pub trait SchemaPrimitiveField {
             result.push(Self::index(object, field, index));
         }
         result
+    }
+}
+
+mod private {
+    pub unsafe trait PointerType: Sized {
+        type Raw;
+
+        unsafe fn from_raw<'a>(raw: *mut Self::Raw) -> &'a Self {
+            &*(raw as *mut _)
+        }
+
+        unsafe fn from_raw_mut<'a>(raw: *mut Self::Raw) -> &'a mut Self {
+            &mut *(raw as *mut _)
+        }
+
+        fn as_ptr(&self) -> *mut Self::Raw {
+            self as *const _ as *mut _
+        }
     }
 }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -41,6 +41,8 @@ pub trait SchemaPrimitiveField {
     }
 }
 
+// NOTE: We define these traits within a private module so that we can also use them
+// to seal public traits (e.g. `owned::Ownable`).
 mod private {
     /// A type that acts as an alias to some schema data hidden behind a pointer.
     ///
@@ -111,6 +113,10 @@ mod private {
     }
 
     /// A data pointer type that can be owned directly by user code.
+    ///
+    /// All of the data pointer types except `SchemaObject` can be directly owned by the
+    /// user via the `Owned<T>` smart pointer type. This trait defines the constructor
+    /// and destructor functions for the underlying C data needed for this purpose.
     pub unsafe trait OwnedPointer: DataPointer {
         const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw;
         const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw);

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -10,6 +10,7 @@ mod component_data;
 mod component_update;
 mod object;
 mod primitives;
+mod ptr;
 
 pub mod owned;
 
@@ -18,7 +19,7 @@ pub use self::{
     owned::Owned, primitives::*,
 };
 
-pub(crate) use self::private::*;
+pub(crate) use self::ptr::*;
 
 pub type FieldId = u32;
 
@@ -38,87 +39,5 @@ pub trait SchemaPrimitiveField {
             result.push(Self::index(object, field, index));
         }
         result
-    }
-}
-
-// NOTE: We define these traits within a private module so that we can also use them
-// to seal public traits (e.g. `owned::Ownable`).
-mod private {
-    /// A type that acts as an alias to some schema data hidden behind a pointer.
-    ///
-    /// `Schema_Object` and the related schema data "wrapper types" are all represented
-    /// as opaque types hidden behind pointers in the C API; You always work with a
-    /// pointer to the struct, never an instance of the struct itself. To represent
-    /// these in Rust, we define dummy types that can similarly always be put behind a
-    /// reference without ever allowing the user to directly "hold" an instance of the
-    /// type. This allows us to simply cast the raw pointer to a reference to our dummy
-    /// type and preserve the desired semantics of working with a reference, including
-    /// the ownership rules and lifetimes that come with it.
-    ///
-    /// This trait is implemented for all such types, and provides the common methods
-    /// used for type punning with the raw pointer.
-    ///
-    /// # Safety
-    ///
-    /// In order for the implementation of this trait to be safe, the following
-    /// invariants must be upheld:
-    ///
-    /// * It must be a [zero sized type][zst].
-    /// * It must have a private field, such that the type can never be directly
-    ///   instantiated by a user.
-    /// * A reference to `Self` must never be de-referenced. It may only ever be
-    ///   converted to a pointer with `as_ptr()`, which may then be passed to the
-    ///   appropriate functions in the C API.
-    ///
-    /// The `pointer_type_tests!` macro should be used to generate tests for any type
-    /// implementing this trait.
-    ///
-    /// [zst]:  https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts
-    ///
-    /// # Ownable Types
-    ///
-    /// This trait broadly covers all types that can be converted from a pointer to a
-    /// reference, but some of the types (well, all of them except `SchemaObject`) can
-    /// also be owned in addition to being borrowed. For these, see the `owned` module
-    /// and its corresponding `Ownable` trait which extends `DataPointer` with
-    /// additional functionality for creating and destroying owned instances of the
-    /// type.
-    ///
-    /// # Extern Types
-    ///
-    /// There is an [accepted RFC][rfc] for more accurately representing types like
-    /// this. If it is ever implemented and stabilized, we should switch to representing
-    /// these types as extern types, as it would better enforce necessary safety
-    /// invariants.
-    ///
-    /// [rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1861-extern-types.md
-    pub unsafe trait DataPointer: Sized {
-        type Raw;
-
-        unsafe fn from_raw<'a>(raw: *const Self::Raw) -> &'a Self {
-            &*(raw as *const _)
-        }
-
-        unsafe fn from_raw_mut<'a>(raw: *mut Self::Raw) -> &'a mut Self {
-            &mut *(raw as *mut _)
-        }
-
-        fn as_ptr(&self) -> *const Self::Raw {
-            self as *const _ as *const _
-        }
-
-        fn as_ptr_mut(&mut self) -> *mut Self::Raw {
-            self as *mut _ as *mut _
-        }
-    }
-
-    /// A data pointer type that can be owned directly by user code.
-    ///
-    /// All of the data pointer types except `SchemaObject` can be directly owned by the
-    /// user via the `Owned<T>` smart pointer type. This trait defines the constructor
-    /// and destructor functions for the underlying C data needed for this purpose.
-    pub unsafe trait OwnedPointer: DataPointer {
-        const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw;
-        const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw);
     }
 }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -93,8 +93,8 @@ mod private {
     pub unsafe trait PointerType: Sized {
         type Raw;
 
-        unsafe fn from_raw<'a>(raw: *mut Self::Raw) -> &'a Self {
-            &*(raw as *mut _)
+        unsafe fn from_raw<'a>(raw: *const Self::Raw) -> &'a Self {
+            &*(raw as *const _)
         }
 
         unsafe fn from_raw_mut<'a>(raw: *mut Self::Raw) -> &'a mut Self {

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -18,7 +18,7 @@ pub use self::{
     owned::Owned, primitives::*,
 };
 
-pub(crate) use self::private::PointerType;
+pub(crate) use self::private::*;
 
 pub type FieldId = u32;
 
@@ -108,5 +108,11 @@ mod private {
         fn as_ptr_mut(&mut self) -> *mut Self::Raw {
             self as *mut _ as *mut _
         }
+    }
+
+    /// A data pointer type that can be owned directly by user code.
+    pub unsafe trait OwnedPointer: PointerType {
+        const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw;
+        const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw);
     }
 }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -78,7 +78,7 @@ mod private {
     /// This trait broadly covers all types that can be converted from a pointer to a
     /// reference, but some of the types (well, all of them except `SchemaObject`) can
     /// also be owned in addition to being borrowed. For these, see the `owned` module
-    /// and its corresponding `Ownable` trait which extends `PointerType` with
+    /// and its corresponding `Ownable` trait which extends `DataPointer` with
     /// additional functionality for creating and destroying owned instances of the
     /// type.
     ///
@@ -90,7 +90,7 @@ mod private {
     /// invariants.
     ///
     /// [rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1861-extern-types.md
-    pub unsafe trait PointerType: Sized {
+    pub unsafe trait DataPointer: Sized {
         type Raw;
 
         unsafe fn from_raw<'a>(raw: *const Self::Raw) -> &'a Self {
@@ -111,7 +111,7 @@ mod private {
     }
 
     /// A data pointer type that can be owned directly by user code.
-    pub unsafe trait OwnedPointer: PointerType {
+    pub unsafe trait OwnedPointer: DataPointer {
         const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw;
         const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw);
     }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -101,8 +101,12 @@ mod private {
             &mut *(raw as *mut _)
         }
 
-        fn as_ptr(&self) -> *mut Self::Raw {
-            self as *const _ as *mut _
+        fn as_ptr(&self) -> *const Self::Raw {
+            self as *const _ as *const _
+        }
+
+        fn as_ptr_mut(&mut self) -> *mut Self::Raw {
+            self as *mut _ as *mut _
         }
     }
 }

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -36,9 +36,5 @@ unsafe impl Send for SchemaCommandRequest {}
 
 #[cfg(test)]
 mod tests {
-    use super::SchemaCommandRequest;
-    use static_assertions::*;
-
-    assert_impl_all!(SchemaCommandRequest: Send);
-    assert_not_impl_any!(SchemaCommandRequest: Sync);
+    pointer_type_tests!(super::SchemaCommandRequest);
 }

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -17,17 +17,6 @@ impl SchemaCommandRequest {
     pub fn object_mut(&mut self) -> &mut SchemaObject {
         unsafe { SchemaObject::from_raw_mut(Schema_GetCommandRequestObject(self.as_ptr())) }
     }
-
-    // Methods for raw pointer conversion.
-    // -----------------------------------
-
-    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_CommandRequest) -> &'a Self {
-        &*(raw as *mut _)
-    }
-
-    pub(crate) fn as_ptr(&self) -> *mut Schema_CommandRequest {
-        self as *const _ as *mut _
-    }
 }
 
 unsafe impl PointerType for SchemaCommandRequest {

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
+use crate::worker::schema::{DataPointer, Owned, OwnedPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{owned::OwnableImpl, Owned, SchemaObject};
+use crate::worker::schema::{owned::OwnableImpl, Owned, PointerType, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -7,7 +7,7 @@ pub struct SchemaCommandRequest(PhantomData<*mut Schema_CommandRequest>);
 
 impl SchemaCommandRequest {
     pub fn new() -> Owned<SchemaCommandRequest> {
-        unsafe { Owned::new(Schema_CreateCommandRequest()) }
+        Owned::new()
     }
 
     pub fn object(&self) -> &SchemaObject {
@@ -30,12 +30,13 @@ impl SchemaCommandRequest {
     }
 }
 
-impl OwnableImpl for SchemaCommandRequest {
+unsafe impl PointerType for SchemaCommandRequest {
     type Raw = Schema_CommandRequest;
+}
 
-    unsafe fn destroy(me: *mut Self::Raw) {
-        Schema_DestroyCommandRequest(me);
-    }
+unsafe impl OwnableImpl for SchemaCommandRequest {
+    const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw = Schema_CreateCommandRequest;
+    const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw) = Schema_DestroyCommandRequest;
 }
 
 // SAFETY: It should be safe to send a `SchemaCommandRequest` between threads, so long as

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{owned::OwnableImpl, Owned, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -23,7 +23,7 @@ unsafe impl PointerType for SchemaCommandRequest {
     type Raw = Schema_CommandRequest;
 }
 
-unsafe impl OwnableImpl for SchemaCommandRequest {
+unsafe impl OwnedPointer for SchemaCommandRequest {
     const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw = Schema_CreateCommandRequest;
     const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw) = Schema_DestroyCommandRequest;
 }

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -19,7 +19,7 @@ impl SchemaCommandRequest {
     }
 }
 
-unsafe impl PointerType for SchemaCommandRequest {
+unsafe impl DataPointer for SchemaCommandRequest {
     type Raw = Schema_CommandRequest;
 }
 

--- a/spatialos-sdk/src/worker/schema/command_request.rs
+++ b/spatialos-sdk/src/worker/schema/command_request.rs
@@ -11,11 +11,11 @@ impl SchemaCommandRequest {
     }
 
     pub fn object(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetCommandRequestObject(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw(Schema_GetCommandRequestObject(self.as_ptr() as *mut _)) }
     }
 
     pub fn object_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandRequestObject(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandRequestObject(self.as_ptr_mut())) }
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
+use crate::worker::schema::{DataPointer, Owned, OwnedPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{owned::OwnableImpl, Owned, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -23,7 +23,7 @@ unsafe impl PointerType for SchemaCommandResponse {
     type Raw = Schema_CommandResponse;
 }
 
-unsafe impl OwnableImpl for SchemaCommandResponse {
+unsafe impl OwnedPointer for SchemaCommandResponse {
     const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw = Schema_CreateCommandResponse;
     const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw) = Schema_DestroyCommandResponse;
 }

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -17,17 +17,6 @@ impl SchemaCommandResponse {
     pub fn object_mut(&mut self) -> &mut SchemaObject {
         unsafe { SchemaObject::from_raw_mut(Schema_GetCommandResponseObject(self.as_ptr())) }
     }
-
-    // Methods for raw pointer conversion.
-    // -----------------------------------
-
-    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_CommandResponse) -> &'a Self {
-        &*(raw as *mut _)
-    }
-
-    pub(crate) fn as_ptr(&self) -> *mut Schema_CommandResponse {
-        self as *const _ as *mut _
-    }
 }
 
 unsafe impl PointerType for SchemaCommandResponse {

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -36,9 +36,5 @@ unsafe impl Send for SchemaCommandResponse {}
 
 #[cfg(test)]
 mod tests {
-    use super::SchemaCommandResponse;
-    use static_assertions::*;
-
-    assert_impl_all!(SchemaCommandResponse: Send);
-    assert_not_impl_any!(SchemaCommandResponse: Sync);
+    pointer_type_tests!(super::SchemaCommandResponse);
 }

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -11,11 +11,11 @@ impl SchemaCommandResponse {
     }
 
     pub fn object(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetCommandResponseObject(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw(Schema_GetCommandResponseObject(self.as_ptr() as *mut _)) }
     }
 
     pub fn object_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandResponseObject(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetCommandResponseObject(self.as_ptr_mut())) }
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{owned::OwnableImpl, Owned, SchemaObject};
+use crate::worker::schema::{owned::OwnableImpl, Owned, PointerType, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -7,7 +7,7 @@ pub struct SchemaCommandResponse(PhantomData<*mut Schema_CommandResponse>);
 
 impl SchemaCommandResponse {
     pub fn new() -> Owned<SchemaCommandResponse> {
-        unsafe { Owned::new(Schema_CreateCommandResponse()) }
+        Owned::new()
     }
 
     pub fn object(&self) -> &SchemaObject {
@@ -30,12 +30,13 @@ impl SchemaCommandResponse {
     }
 }
 
-impl OwnableImpl for SchemaCommandResponse {
+unsafe impl PointerType for SchemaCommandResponse {
     type Raw = Schema_CommandResponse;
+}
 
-    unsafe fn destroy(me: *mut Self::Raw) {
-        Schema_DestroyCommandResponse(me);
-    }
+unsafe impl OwnableImpl for SchemaCommandResponse {
+    const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw = Schema_CreateCommandResponse;
+    const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw) = Schema_DestroyCommandResponse;
 }
 
 // SAFETY: It should be safe to send a `SchemaCommandResonse` between threads, so long as

--- a/spatialos-sdk/src/worker/schema/command_response.rs
+++ b/spatialos-sdk/src/worker/schema/command_response.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -19,7 +19,7 @@ impl SchemaCommandResponse {
     }
 }
 
-unsafe impl PointerType for SchemaCommandResponse {
+unsafe impl DataPointer for SchemaCommandResponse {
     type Raw = Schema_CommandResponse;
 }
 

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
+use crate::worker::schema::{DataPointer, Owned, OwnedPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{owned::OwnableImpl, Owned, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -25,17 +25,11 @@ impl SchemaComponentData {
     }
 }
 
-impl Default for Owned<SchemaComponentData> {
-    fn default() -> Self {
-        SchemaComponentData::new()
-    }
-}
-
 unsafe impl PointerType for SchemaComponentData {
     type Raw = Schema_ComponentData;
 }
 
-unsafe impl OwnableImpl for SchemaComponentData {
+unsafe impl OwnedPointer for SchemaComponentData {
     const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw = Schema_CreateComponentData;
     const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw) = Schema_DestroyComponentData;
 }

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -48,9 +48,5 @@ unsafe impl Send for SchemaComponentData {}
 
 #[cfg(test)]
 mod test {
-    use super::SchemaComponentData;
-    use static_assertions::*;
-
-    assert_impl_all!(SchemaComponentData: Send);
-    assert_not_impl_any!(SchemaComponentData: Sync);
+    pointer_type_tests!(super::SchemaComponentData);
 }

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -17,11 +17,11 @@ impl SchemaComponentData {
     }
 
     pub fn fields(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetComponentDataFields(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw(Schema_GetComponentDataFields(self.as_ptr() as *mut _)) }
     }
 
     pub fn fields_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentDataFields(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentDataFields(self.as_ptr_mut())) }
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -25,7 +25,7 @@ impl SchemaComponentData {
     }
 }
 
-unsafe impl PointerType for SchemaComponentData {
+unsafe impl DataPointer for SchemaComponentData {
     type Raw = Schema_ComponentData;
 }
 

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -11,19 +11,19 @@ impl SchemaComponentUpdate {
     }
 
     pub fn fields(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateFields(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateFields(self.as_ptr() as *mut _)) }
     }
 
     pub fn fields_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateFields(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateFields(self.as_ptr_mut())) }
     }
 
     pub fn events(&self) -> &SchemaObject {
-        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateEvents(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw(Schema_GetComponentUpdateEvents(self.as_ptr() as *mut _)) }
     }
 
     pub fn events_mut(&mut self) -> &mut SchemaObject {
-        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateEvents(self.as_ptr())) }
+        unsafe { SchemaObject::from_raw_mut(Schema_GetComponentUpdateEvents(self.as_ptr_mut())) }
     }
 
     // TODO: Cleared fields.

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
+use crate::worker::schema::{DataPointer, Owned, OwnedPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -46,9 +46,5 @@ unsafe impl Send for SchemaComponentUpdate {}
 
 #[cfg(test)]
 mod tests {
-    use super::SchemaComponentUpdate;
-    use static_assertions::*;
-
-    assert_impl_all!(SchemaComponentUpdate: Send);
-    assert_not_impl_any!(SchemaComponentUpdate: Sync);
+    pointer_type_tests!(super::SchemaComponentUpdate);
 }

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, DataPointer, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -29,7 +29,7 @@ impl SchemaComponentUpdate {
     // TODO: Cleared fields.
 }
 
-unsafe impl PointerType for SchemaComponentUpdate {
+unsafe impl DataPointer for SchemaComponentUpdate {
     type Raw = Schema_ComponentUpdate;
 }
 

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{owned::OwnableImpl, Owned, PointerType, SchemaObject};
+use crate::worker::schema::{Owned, OwnedPointer, PointerType, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -33,7 +33,7 @@ unsafe impl PointerType for SchemaComponentUpdate {
     type Raw = Schema_ComponentUpdate;
 }
 
-unsafe impl OwnableImpl for SchemaComponentUpdate {
+unsafe impl OwnedPointer for SchemaComponentUpdate {
     const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw = Schema_CreateComponentUpdate;
     const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw) = Schema_DestroyComponentUpdate;
 }

--- a/spatialos-sdk/src/worker/schema/component_update.rs
+++ b/spatialos-sdk/src/worker/schema/component_update.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{owned::OwnableImpl, Owned, SchemaObject};
+use crate::worker::schema::{owned::OwnableImpl, Owned, PointerType, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -7,7 +7,7 @@ pub struct SchemaComponentUpdate(PhantomData<*mut Schema_ComponentUpdate>);
 
 impl SchemaComponentUpdate {
     pub fn new() -> Owned<SchemaComponentUpdate> {
-        unsafe { Owned::new(Schema_CreateComponentUpdate()) }
+        Owned::new()
     }
 
     pub fn fields(&self) -> &SchemaObject {
@@ -27,25 +27,15 @@ impl SchemaComponentUpdate {
     }
 
     // TODO: Cleared fields.
-
-    // Methods for raw pointer conversion.
-    // -----------------------------------
-
-    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_ComponentUpdate) -> &'a Self {
-        &*(raw as *mut _)
-    }
-
-    pub(crate) fn as_ptr(&self) -> *mut Schema_ComponentUpdate {
-        self as *const _ as *mut _
-    }
 }
 
-impl OwnableImpl for SchemaComponentUpdate {
+unsafe impl PointerType for SchemaComponentUpdate {
     type Raw = Schema_ComponentUpdate;
+}
 
-    unsafe fn destroy(me: *mut Self::Raw) {
-        Schema_DestroyComponentUpdate(me);
-    }
+unsafe impl OwnableImpl for SchemaComponentUpdate {
+    const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw = Schema_CreateComponentUpdate;
+    const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw) = Schema_DestroyComponentUpdate;
 }
 
 // SAFETY: It should be safe to send a `SchemaComponentUpdate` between threads, so long as

--- a/spatialos-sdk/src/worker/schema/macros.rs
+++ b/spatialos-sdk/src/worker/schema/macros.rs
@@ -8,14 +8,14 @@
 /// * Verify that the type implements `Send`.
 /// * Verify that the type does not implement `Sync`.
 ///
-/// See the documentation for `PointerType` for more details about the safety
+/// See the documentation for `DataPointer` for more details about the safety
 /// invariants that these tests enforce.
 macro_rules! pointer_type_tests {
     ($type:ty) => {
         static_assertions::const_assert!(std::mem::size_of::<$type>() == 0);
 
         static_assertions::assert_eq_align!(
-            *mut <$type as $crate::worker::schema::private::PointerType>::Raw,
+            *mut <$type as $crate::worker::schema::private::DataPointer>::Raw,
             &$type,
             &mut $type,
         );

--- a/spatialos-sdk/src/worker/schema/macros.rs
+++ b/spatialos-sdk/src/worker/schema/macros.rs
@@ -1,0 +1,15 @@
+#[cfg(test)]
+macro_rules! pointer_type_tests {
+    ($type:ty) => {
+        static_assertions::const_assert!(std::mem::size_of::<$type>() == 0);
+
+        static_assertions::assert_eq_align!(
+            *mut <$type as $crate::worker::schema::private::PointerType>::Raw,
+            &$type,
+            &mut $type,
+        );
+
+        static_assertions::assert_impl_all!($type: Send);
+        static_assertions::assert_not_impl_any!($type: Sync);
+    };
+}

--- a/spatialos-sdk/src/worker/schema/macros.rs
+++ b/spatialos-sdk/src/worker/schema/macros.rs
@@ -15,7 +15,7 @@ macro_rules! pointer_type_tests {
         static_assertions::const_assert!(std::mem::size_of::<$type>() == 0);
 
         static_assertions::assert_eq_align!(
-            *mut <$type as $crate::worker::schema::private::DataPointer>::Raw,
+            *mut <$type as $crate::worker::schema::ptr::DataPointer>::Raw,
             &$type,
             &mut $type,
         );

--- a/spatialos-sdk/src/worker/schema/macros.rs
+++ b/spatialos-sdk/src/worker/schema/macros.rs
@@ -1,4 +1,15 @@
-#[cfg(test)]
+/// Generates static assertion tests around safety invariants for pointer types.
+///
+/// Generates the following tests:
+///
+/// * Verify that the type is zero sized.
+/// * Verify that the alignment of the raw pointer matches the alignment of
+///   references to the Rust type.
+/// * Verify that the type implements `Send`.
+/// * Verify that the type does not implement `Sync`.
+///
+/// See the documentation for `PointerType` for more details about the safety
+/// invariants that these tests enforce.
 macro_rules! pointer_type_tests {
     ($type:ty) => {
         static_assertions::const_assert!(std::mem::size_of::<$type>() == 0);

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{FieldId, PointerType, SchemaPrimitiveField};
+use crate::worker::schema::{FieldId, DataPointer, SchemaPrimitiveField};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -54,7 +54,7 @@ impl SchemaObject {
     }
 }
 
-unsafe impl PointerType for SchemaObject {
+unsafe impl DataPointer for SchemaObject {
     type Raw = Schema_Object;
 }
 

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -31,7 +31,7 @@ impl SchemaObject {
     }
 
     pub fn get_object(&self, field: FieldId) -> &SchemaObject {
-        unsafe { Self::from_raw(Schema_GetObject(self.as_ptr(), field)) }
+        unsafe { Self::from_raw(Schema_GetObject(self.as_ptr() as *mut _, field)) }
     }
 
     pub fn object_count(&self, field: FieldId) -> usize {
@@ -40,7 +40,13 @@ impl SchemaObject {
     }
 
     pub fn index_object(&self, field: FieldId, index: usize) -> &SchemaObject {
-        unsafe { Self::from_raw(Schema_IndexObject(self.as_ptr(), field, index as u32)) }
+        unsafe {
+            Self::from_raw(Schema_IndexObject(
+                self.as_ptr() as *mut _,
+                field,
+                index as u32,
+            ))
+        }
     }
 
     pub fn add_object(&mut self, field: FieldId) -> &mut SchemaObject {

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -44,7 +44,7 @@ impl SchemaObject {
     }
 
     pub fn add_object(&mut self, field: FieldId) -> &mut SchemaObject {
-        unsafe { Self::from_raw_mut(Schema_AddObject(self.as_ptr(), field)) }
+        unsafe { Self::from_raw_mut(Schema_AddObject(self.as_ptr_mut(), field)) }
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{FieldId, SchemaPrimitiveField};
+use crate::worker::schema::{FieldId, PointerType, SchemaPrimitiveField};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -46,21 +46,10 @@ impl SchemaObject {
     pub fn add_object(&mut self, field: FieldId) -> &mut SchemaObject {
         unsafe { Self::from_raw_mut(Schema_AddObject(self.as_ptr(), field)) }
     }
+}
 
-    // Methods for raw pointer conversion.
-    // -----------------------------------
-
-    pub(crate) unsafe fn from_raw<'a>(raw: *mut Schema_Object) -> &'a Self {
-        &*(raw as *mut _)
-    }
-
-    pub(crate) unsafe fn from_raw_mut<'a>(raw: *mut Schema_Object) -> &'a mut Self {
-        &mut *(raw as *mut _)
-    }
-
-    pub(crate) fn as_ptr(&self) -> *mut Schema_Object {
-        self as *const _ as *mut _
-    }
+unsafe impl PointerType for SchemaObject {
+    type Raw = Schema_Object;
 }
 
 // SAFETY: It should be safe to send a `SchemaObject` between threads, so long as

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -59,10 +59,6 @@ unsafe impl PointerType for SchemaObject {
 unsafe impl Send for SchemaObject {}
 
 #[cfg(test)]
-mod test {
-    use super::SchemaObject;
-    use static_assertions::*;
-
-    assert_impl_all!(SchemaObject: Send);
-    assert_not_impl_any!(SchemaObject: Sync);
+mod tests {
+    pointer_type_tests!(super::SchemaObject);
 }

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{FieldId, DataPointer, SchemaPrimitiveField};
+use crate::worker::schema::{DataPointer, FieldId, SchemaPrimitiveField};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 

--- a/spatialos-sdk/src/worker/schema/owned.rs
+++ b/spatialos-sdk/src/worker/schema/owned.rs
@@ -14,13 +14,12 @@
 //! [`Owned`]: struct.Owned.html
 //! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
 
+use crate::worker::schema::OwnedPointer;
 use std::{
     mem,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
-
-use crate::worker::schema::private::OwnedPointer;
 
 pub trait Ownable: OwnedPointer {}
 

--- a/spatialos-sdk/src/worker/schema/primitives.rs
+++ b/spatialos-sdk/src/worker/schema/primitives.rs
@@ -1,5 +1,5 @@
 use crate::worker::{
-    schema::{FieldId, DataPointer, SchemaObject, SchemaPrimitiveField},
+    schema::{DataPointer, FieldId, SchemaObject, SchemaPrimitiveField},
     EntityId,
 };
 use spatialos_sdk_sys::worker::*;

--- a/spatialos-sdk/src/worker/schema/primitives.rs
+++ b/spatialos-sdk/src/worker/schema/primitives.rs
@@ -1,5 +1,5 @@
 use crate::worker::{
-    schema::{FieldId, PointerType, SchemaObject, SchemaPrimitiveField},
+    schema::{FieldId, DataPointer, SchemaObject, SchemaPrimitiveField},
     EntityId,
 };
 use spatialos_sdk_sys::worker::*;

--- a/spatialos-sdk/src/worker/schema/primitives.rs
+++ b/spatialos-sdk/src/worker/schema/primitives.rs
@@ -1,5 +1,5 @@
 use crate::worker::{
-    schema::{FieldId, SchemaObject, SchemaPrimitiveField},
+    schema::{FieldId, PointerType, SchemaObject, SchemaPrimitiveField},
     EntityId,
 };
 use spatialos_sdk_sys::worker::*;

--- a/spatialos-sdk/src/worker/schema/primitives.rs
+++ b/spatialos-sdk/src/worker/schema/primitives.rs
@@ -35,7 +35,7 @@ macro_rules! impl_primitive_field {
 
             fn add(object: &mut SchemaObject, field: FieldId, value: &$rust_type) {
                 unsafe {
-                    $schema_add(object.as_ptr(), field, *value);
+                    $schema_add(object.as_ptr_mut(), field, *value);
                 }
             }
 
@@ -46,7 +46,7 @@ macro_rules! impl_primitive_field {
                     .try_into()
                     .expect("Cannot work with a super long array");
                 unsafe {
-                    $schema_add_list(object.as_ptr(), field, ptr, len);
+                    $schema_add_list(object.as_ptr_mut(), field, ptr, len);
                 }
             }
         }
@@ -197,7 +197,7 @@ impl SchemaPrimitiveField for SchemaEntityId {
 
     fn add(object: &mut SchemaObject, field: FieldId, value: &EntityId) {
         unsafe {
-            Schema_AddEntityId(object.as_ptr(), field, value.id);
+            Schema_AddEntityId(object.as_ptr_mut(), field, value.id);
         }
     }
 
@@ -205,7 +205,7 @@ impl SchemaPrimitiveField for SchemaEntityId {
         let converted_list: Vec<i64> = value.iter().map(|v| v.id).collect();
         unsafe {
             let ptr = converted_list.as_ptr();
-            Schema_AddEntityIdList(object.as_ptr(), field, ptr, value.len() as u32);
+            Schema_AddEntityIdList(object.as_ptr_mut(), field, ptr, value.len() as u32);
         }
     }
 }
@@ -227,7 +227,7 @@ impl SchemaPrimitiveField for SchemaBool {
 
     fn add(object: &mut SchemaObject, field: FieldId, value: &Self::RustType) {
         unsafe {
-            Schema_AddBool(object.as_ptr(), field, *value as u8);
+            Schema_AddBool(object.as_ptr_mut(), field, *value as u8);
         }
     }
 
@@ -235,7 +235,7 @@ impl SchemaPrimitiveField for SchemaBool {
         let converted_list: Vec<u8> = value.iter().map(|v| if *v { 1u8 } else { 0u8 }).collect();
         unsafe {
             let ptr = converted_list.as_ptr();
-            Schema_AddBoolList(object.as_ptr(), field, ptr, value.len() as u32);
+            Schema_AddBoolList(object.as_ptr_mut(), field, ptr, value.len() as u32);
         }
     }
 }
@@ -269,7 +269,7 @@ impl SchemaPrimitiveField for SchemaString {
         let utf8_bytes = value.as_bytes();
         unsafe {
             Schema_AddBytes(
-                object.as_ptr(),
+                object.as_ptr_mut(),
                 field,
                 utf8_bytes.as_ptr(),
                 utf8_bytes.len() as u32,
@@ -311,7 +311,12 @@ impl SchemaPrimitiveField for SchemaBytes {
 
     fn add(object: &mut SchemaObject, field: FieldId, value: &Vec<u8>) {
         unsafe {
-            Schema_AddBytes(object.as_ptr(), field, value.as_ptr(), value.len() as u32);
+            Schema_AddBytes(
+                object.as_ptr_mut(),
+                field,
+                value.as_ptr(),
+                value.len() as u32,
+            );
         }
     }
 

--- a/spatialos-sdk/src/worker/schema/ptr.rs
+++ b/spatialos-sdk/src/worker/schema/ptr.rs
@@ -1,0 +1,101 @@
+//! Handling for schema data types that act like pointers.
+//!
+//! `Schema_Object` and the related schema data "wrapper types" are all represented
+//! as opaque types hidden behind pointers in the C API; You always work with a
+//! pointer to the struct, never an instance of the struct itself. To represent
+//! these in Rust, we define dummy types that can similarly always be put behind a
+//! reference without ever allowing the user to directly "hold" an instance of the
+//! type. This allows us to simply cast the raw pointer to a reference to our dummy
+//! type and preserve the desired semantics of working with a reference, including
+//! the ownership rules and lifetimes that come with it.
+//!
+//! The `DataPointer` trait is implemented for all such types, and provides the
+//! common methods used for type punning with the raw pointer.
+//!
+//! # Safety
+//!
+//! In order for the implementation of `DataPointer` to be safe, the following
+//! invariants must be upheld:
+//!
+//! * It must be a [zero sized type][zst].
+//! * It must have a private field, such that the type can never be directly
+//!   instantiated by a user.
+//! * It must never be instantiated directly within the SDK. Instances may only ever
+//!   be created by casting the raw pointers returned from the appropriate C API
+//!   functions.
+//! * A reference to `Self` must never be de-referenced. It may only ever be
+//!   converted to a pointer with `as_ptr()`, which may then be passed to the
+//!   appropriate functions in the C API.
+//! * The type may be `Send`, but it must not be `Sync`.
+//!
+//! The `pointer_type_tests!` macro should be used to generate tests for any type
+//! implementing this trait.
+//!
+//! # Extern Types
+//!
+//! There is an [accepted RFC][rfc] for more accurately representing types like
+//! this. If it is ever implemented and stabilized, we should switch to representing
+//! these types as extern types, as it would better enforce necessary safety
+//! invariants.
+//!
+//! Until then, enforcing that the types are zero-sized and have a dummy private
+//! field is the closest we can come to ensuring the type is safe to use. We must
+//! also be sure to never directly instantiate the type *within* the SDK.
+//!
+//! # Interior Mutability and Thread Safety
+//!
+//! The `as_ptr_mut` method requires `&mut self` in order to get a mutable raw
+//! pointer to the underlying data, however there are some cases where the C API
+//! function takes a `*mut T` where the corresponding Rust function makes more sense
+//! taking `&self`. For example, `SchemaObject::get_object` takes `&self` and
+//! returns a `&SchemaObject`, indicating it would be safe to call it multiple times
+//! and get multiple simultaneous borrows of the same inner object. The underlying
+//! C function `Schema_GetObject` takes a `*mut Schema_Object` because a dummy
+//! object may need to be created if there is not already an object in the specified
+//! field.
+//!
+//! This setup, where the underlying data may be mutated through an immutable
+//! reference, is a form of [interior mutability] and is still safe as long as we
+//! maintain the necessary invariants. In particular, our Rust types cannot be
+//! `Sync` because the mutability happening within the C SDK is unsynchronized.
+//! The other key invariant is that we must ensure that a reference returned by a
+//! method taking `&self` can never be invalidated by another method taking `&self`,
+//! however the C API already guarantees this behavior in all cases and so is not
+//! something we specifically have to enforce within the Rust SDK.
+//!
+//! [zst]:  https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts
+//! [rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1861-extern-types.md
+//! [interior mutability]: https://doc.rust-lang.org/book/ch15-05-interior-mutability.html
+
+/// A type that acts as an alias to some schema data hidden behind a pointer.
+///
+/// See the module-level docs for more information.
+pub unsafe trait DataPointer: Sized {
+    type Raw;
+
+    unsafe fn from_raw<'a>(raw: *const Self::Raw) -> &'a Self {
+        &*(raw as *const _)
+    }
+
+    unsafe fn from_raw_mut<'a>(raw: *mut Self::Raw) -> &'a mut Self {
+        &mut *(raw as *mut _)
+    }
+
+    fn as_ptr(&self) -> *const Self::Raw {
+        self as *const _ as *const _
+    }
+
+    fn as_ptr_mut(&mut self) -> *mut Self::Raw {
+        self as *mut _ as *mut _
+    }
+}
+
+/// A data pointer type that can be owned directly by user code.
+///
+/// All of the data pointer types except `SchemaObject` can be directly owned by the
+/// user via the `Owned<T>` smart pointer type. This trait defines the constructor
+/// and destructor functions for the underlying C data needed for this purpose.
+pub unsafe trait OwnedPointer: DataPointer {
+    const CREATE_FN: unsafe extern "C" fn() -> *mut Self::Raw;
+    const DESTROY_FN: unsafe extern "C" fn(*mut Self::Raw);
+}


### PR DESCRIPTION
> Part of #121

This PR is a cleanup pass after the previous work done to fix the soundness holes in the schema data object types (#127, #128, and #129).

I've added the `DataPointer` trait to unify the functionality for handling the schema data objects. It provides default functions for converting between Rust references and the raw pointer representation, removing the need to have that logic duplicated for each type. I've also added documentation around the invariants that must be maintained in order to for the implementation to be safe.

Per @jamiebrynes7's suggestion, I've changed `as_ptr` to return a `*const Self::Raw` and added a separate `as_ptr_mut` method. In the cases where a method taking `&self` calls a C function that needs `*mut T`, we manually cast the pointer types. The safety invariants around this are documented in the "Interior Mutability and Thread Safey" section of the `ptr` module docs.

Lastly, I've added a `pointer_type_tests!` macro to generate a set of assertion tests for each of these types to help ensure we're enforcing the necessary safety invariants.