### PR TITLE
Unify serialization logic

### DIFF
--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -938,12 +938,12 @@ impl TypeConversion for EntityAcl {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
             read_acl: <generated::improbable::WorkerRequirementSet as TypeConversion>::from_type(&input.get_object(1))?,
-            component_write_acl: { let size = input.object_count(2); let mut m = BTreeMap::new(); for i in 0..size { let kv = input.index_object(2, i); m.insert(kv.get::<SchemaUint32>(1), <generated::improbable::WorkerRequirementSet as TypeConversion>::from_type(&kv.get_object(2))?); }; m },
+            component_write_acl: input.get::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         <generated::improbable::WorkerRequirementSet as TypeConversion>::to_type(&&input.read_acl, &mut output.add_object(1))?;
-        for (k, v) in &input.component_write_acl { let mut object = output.add_object(2); object.add::<SchemaUint32>(1, k); <generated::improbable::WorkerRequirementSet as TypeConversion>::to_type(&v, &mut object.add_object(2))?; };
+        output.add::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2, &input.component_write_acl);
         Ok(())
     }
 }
@@ -963,7 +963,7 @@ impl TypeConversion for EntityAclUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
             read_acl: if input.object_count(1) > 0 { Some(<generated::improbable::WorkerRequirementSet as TypeConversion>::from_type(&input.get_object(1))?) } else { None },
-            component_write_acl: { let size = input.object_count(2); if size > 0 { let mut m = BTreeMap::new(); for i in 0..size { let kv = input.index_object(2, i); m.insert(kv.get::<SchemaUint32>(1), <generated::improbable::WorkerRequirementSet as TypeConversion>::from_type(&kv.get_object(2))?); } Some(m) } else { None } },
+            component_write_acl: input.get::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
@@ -971,7 +971,7 @@ impl TypeConversion for EntityAclUpdate {
             <generated::improbable::WorkerRequirementSet as TypeConversion>::to_type(&value, &mut output.add_object(1))?;
         }
         if let Some(value) = &input.component_write_acl {
-            for (k, v) in value { let mut object = output.add_object(2); object.add::<SchemaUint32>(1, k); <generated::improbable::WorkerRequirementSet as TypeConversion>::to_type(&v, &mut object.add_object(2))?; };
+            output.add::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2, value);
         }
         Ok(())
     }
@@ -1068,11 +1068,11 @@ pub struct Interest {
 impl TypeConversion for Interest {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            component_interest: { let size = input.object_count(1); let mut m = BTreeMap::new(); for i in 0..size { let kv = input.index_object(1, i); m.insert(kv.get::<SchemaUint32>(1), <generated::improbable::ComponentInterest as TypeConversion>::from_type(&kv.get_object(2))?); }; m },
+            component_interest: input.get::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        for (k, v) in &input.component_interest { let mut object = output.add_object(1); object.add::<SchemaUint32>(1, k); <generated::improbable::ComponentInterest as TypeConversion>::to_type(&v, &mut object.add_object(2))?; };
+        output.add::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1, &input.component_interest);
         Ok(())
     }
 }
@@ -1089,12 +1089,12 @@ pub struct InterestUpdate {
 impl TypeConversion for InterestUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            component_interest: { let size = input.object_count(1); if size > 0 { let mut m = BTreeMap::new(); for i in 0..size { let kv = input.index_object(1, i); m.insert(kv.get::<SchemaUint32>(1), <generated::improbable::ComponentInterest as TypeConversion>::from_type(&kv.get_object(2))?); } Some(m) } else { None } },
+            component_interest: input.get::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         if let Some(value) = &input.component_interest {
-            for (k, v) in value { let mut object = output.add_object(1); object.add::<SchemaUint32>(1, k); <generated::improbable::ComponentInterest as TypeConversion>::to_type(&v, &mut object.add_object(2))?; };
+            output.add::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1, value);
         }
         Ok(())
     }

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -48,7 +48,10 @@ impl TryFrom<u32> for TestEnum {
             
             0 => Ok(TestEnum::FIRST), 
             1 => Ok(TestEnum::SECOND), 
-            _ => Err(UnknownDiscriminantError)
+            _ => Err(UnknownDiscriminantError {
+                type_name: std::any::type_name::<Self>(),
+                value,
+            }),
         }
     }
 }
@@ -1553,7 +1556,10 @@ impl TryFrom<u32> for Connection_ConnectionStatus {
             1 => Ok(Connection_ConnectionStatus::AWAITING_WORKER_CONNECTION), 
             2 => Ok(Connection_ConnectionStatus::CONNECTED), 
             3 => Ok(Connection_ConnectionStatus::DISCONNECTED), 
-            _ => Err(UnknownDiscriminantError)
+            _ => Err(UnknownDiscriminantError {
+                type_name: std::any::type_name::<Self>(),
+                value,
+            }),
         }
     }
 }

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -963,7 +963,7 @@ impl TypeConversion for EntityAclUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
             read_acl: if input.object_count(1) > 0 { Some(<generated::improbable::WorkerRequirementSet as TypeConversion>::from_type(&input.get_object(1))?) } else { None },
-            component_write_acl: input.get::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2),
+            component_write_acl: Some(input.get::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2)),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
@@ -1089,7 +1089,7 @@ pub struct InterestUpdate {
 impl TypeConversion for InterestUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            component_interest: input.get::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1),
+            component_interest: Some(input.get::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1)),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -254,11 +254,11 @@ pub struct EnumTestComponent {
 impl TypeConversion for EnumTestComponent {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            test: From::from(input.get::<SchemaEnum>(1)),
+            test: input.get::<generated::example::TestEnum>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        output.add::<SchemaEnum>(1, &&input.test.as_u32());
+        output.add::<generated::example::TestEnum>(1, &input.test);
         Ok(())
     }
 }
@@ -275,12 +275,12 @@ pub struct EnumTestComponentUpdate {
 impl TypeConversion for EnumTestComponentUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            test: if input.count::<SchemaEnum>(1) > 0 { Some(From::from(input.get::<SchemaEnum>(1))) } else { None },
+            test: if input.count::<SchemaEnum>(1) > 0 { Some(input.get::<generated::example::TestEnum>(1)) } else { None },
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         if let Some(value) = &input.test {
-            output.add::<SchemaEnum>(1, &value.as_u32());
+            output.add::<generated::example::TestEnum>(1, value);
         }
         Ok(())
     }
@@ -519,13 +519,13 @@ impl TypeConversion for Rotate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
             angle: input.get::<SchemaDouble>(1),
-            center: <generated::example::Vector3d as TypeConversion>::from_type(&input.get_object(2))?,
+            center: input.get::<generated::example::Vector3d>(2),
             radius: input.get::<SchemaDouble>(3),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaDouble>(1, &input.angle);
-        <generated::example::Vector3d as TypeConversion>::to_type(&&input.center, &mut output.add_object(2))?;
+        output.add::<generated::example::Vector3d>(2, &input.center);
         output.add::<SchemaDouble>(3, &input.radius);
         Ok(())
     }
@@ -548,7 +548,7 @@ impl TypeConversion for RotateUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
             angle: if input.count::<SchemaDouble>(1) > 0 { Some(input.get::<SchemaDouble>(1)) } else { None },
-            center: if input.object_count(2) > 0 { Some(<generated::example::Vector3d as TypeConversion>::from_type(&input.get_object(2))?) } else { None },
+            center: if input.object_count(2) > 0 { Some(input.get::<generated::example::Vector3d>(2)) } else { None },
             radius: if input.count::<SchemaDouble>(3) > 0 { Some(input.get::<SchemaDouble>(3)) } else { None },
         })
     }
@@ -557,7 +557,7 @@ impl TypeConversion for RotateUpdate {
             output.add::<SchemaDouble>(1, value);
         }
         if let Some(value) = &input.center {
-            <generated::example::Vector3d as TypeConversion>::to_type(&value, &mut output.add_object(2))?;
+            output.add::<generated::example::Vector3d>(2, value);
         }
         if let Some(value) = &input.radius {
             output.add::<SchemaDouble>(3, value);
@@ -670,11 +670,11 @@ pub struct ComponentInterest {
 impl TypeConversion for ComponentInterest {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            queries: { let size = input.object_count(1); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::ComponentInterest_Query as TypeConversion>::from_type(&input.index_object(1, i))?); } l },
+            queries: input.get::<List<generated::improbable::ComponentInterest_Query>>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        for element in (&input.queries).iter() { <generated::improbable::ComponentInterest_Query as TypeConversion>::to_type(&element, &mut output.add_object(1))?; };
+        output.add::<List<generated::improbable::ComponentInterest_Query>>(1, &input.queries);
         Ok(())
     }
 }
@@ -687,13 +687,13 @@ pub struct ComponentInterest_BoxConstraint {
 impl TypeConversion for ComponentInterest_BoxConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            center: <generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?,
-            edge_length: <generated::improbable::EdgeLength as TypeConversion>::from_type(&input.get_object(2))?,
+            center: input.get::<generated::improbable::Coordinates>(1),
+            edge_length: input.get::<generated::improbable::EdgeLength>(2),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::Coordinates as TypeConversion>::to_type(&&input.center, &mut output.add_object(1))?;
-        <generated::improbable::EdgeLength as TypeConversion>::to_type(&&input.edge_length, &mut output.add_object(2))?;
+        output.add::<generated::improbable::Coordinates>(1, &input.center);
+        output.add::<generated::improbable::EdgeLength>(2, &input.edge_length);
         Ok(())
     }
 }
@@ -706,12 +706,12 @@ pub struct ComponentInterest_CylinderConstraint {
 impl TypeConversion for ComponentInterest_CylinderConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            center: <generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?,
+            center: input.get::<generated::improbable::Coordinates>(1),
             radius: input.get::<SchemaDouble>(2),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::Coordinates as TypeConversion>::to_type(&&input.center, &mut output.add_object(1))?;
+        output.add::<generated::improbable::Coordinates>(1, &input.center);
         output.add::<SchemaDouble>(2, &input.radius);
         Ok(())
     }
@@ -727,17 +727,17 @@ pub struct ComponentInterest_Query {
 impl TypeConversion for ComponentInterest_Query {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            constraint: <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::from_type(&input.get_object(1))?,
-            full_snapshot_result: if input.count::<SchemaBool>(2) > 0 { Some(input.get::<SchemaBool>(2)) } else { None },
-            result_component_id: input.get_list::<SchemaUint32>(3),
-            frequency: if input.count::<SchemaFloat>(4) > 0 { Some(input.get::<SchemaFloat>(4)) } else { None },
+            constraint: input.get::<generated::improbable::ComponentInterest_QueryConstraint>(1),
+            full_snapshot_result: input.get::<Optional<SchemaBool>>(2),
+            result_component_id: input.get::<List<SchemaUint32>>(3),
+            frequency: input.get::<Optional<SchemaFloat>>(4),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::to_type(&&input.constraint, &mut output.add_object(1))?;
-        if let Some(data) = &input.full_snapshot_result { output.add::<SchemaBool>(2, data); };
-        output.add_list::<SchemaUint32>(3, &&input.result_component_id[..]);
-        if let Some(data) = &input.frequency { output.add::<SchemaFloat>(4, data); };
+        output.add::<generated::improbable::ComponentInterest_QueryConstraint>(1, &input.constraint);
+        output.add::<Optional<SchemaBool>>(2, &input.full_snapshot_result);
+        output.add::<List<SchemaUint32>>(3, &input.result_component_id);
+        output.add::<Optional<SchemaFloat>>(4, &input.frequency);
         Ok(())
     }
 }
@@ -758,29 +758,29 @@ pub struct ComponentInterest_QueryConstraint {
 impl TypeConversion for ComponentInterest_QueryConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            sphere_constraint: if input.object_count(1) > 0 { Some(<generated::improbable::ComponentInterest_SphereConstraint as TypeConversion>::from_type(&input.get_object(1))?) } else { None },
-            cylinder_constraint: if input.object_count(2) > 0 { Some(<generated::improbable::ComponentInterest_CylinderConstraint as TypeConversion>::from_type(&input.get_object(2))?) } else { None },
-            box_constraint: if input.object_count(3) > 0 { Some(<generated::improbable::ComponentInterest_BoxConstraint as TypeConversion>::from_type(&input.get_object(3))?) } else { None },
-            relative_sphere_constraint: if input.object_count(4) > 0 { Some(<generated::improbable::ComponentInterest_RelativeSphereConstraint as TypeConversion>::from_type(&input.get_object(4))?) } else { None },
-            relative_cylinder_constraint: if input.object_count(5) > 0 { Some(<generated::improbable::ComponentInterest_RelativeCylinderConstraint as TypeConversion>::from_type(&input.get_object(5))?) } else { None },
-            relative_box_constraint: if input.object_count(6) > 0 { Some(<generated::improbable::ComponentInterest_RelativeBoxConstraint as TypeConversion>::from_type(&input.get_object(6))?) } else { None },
-            entity_id_constraint: if input.count::<SchemaInt64>(7) > 0 { Some(input.get::<SchemaInt64>(7)) } else { None },
-            component_constraint: if input.count::<SchemaUint32>(8) > 0 { Some(input.get::<SchemaUint32>(8)) } else { None },
-            and_constraint: { let size = input.object_count(9); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::from_type(&input.index_object(9, i))?); } l },
-            or_constraint: { let size = input.object_count(10); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::from_type(&input.index_object(10, i))?); } l },
+            sphere_constraint: input.get::<Optional<generated::improbable::ComponentInterest_SphereConstraint>>(1),
+            cylinder_constraint: input.get::<Optional<generated::improbable::ComponentInterest_CylinderConstraint>>(2),
+            box_constraint: input.get::<Optional<generated::improbable::ComponentInterest_BoxConstraint>>(3),
+            relative_sphere_constraint: input.get::<Optional<generated::improbable::ComponentInterest_RelativeSphereConstraint>>(4),
+            relative_cylinder_constraint: input.get::<Optional<generated::improbable::ComponentInterest_RelativeCylinderConstraint>>(5),
+            relative_box_constraint: input.get::<Optional<generated::improbable::ComponentInterest_RelativeBoxConstraint>>(6),
+            entity_id_constraint: input.get::<Optional<SchemaInt64>>(7),
+            component_constraint: input.get::<Optional<SchemaUint32>>(8),
+            and_constraint: input.get::<List<generated::improbable::ComponentInterest_QueryConstraint>>(9),
+            or_constraint: input.get::<List<generated::improbable::ComponentInterest_QueryConstraint>>(10),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        if let Some(ref data) = &input.sphere_constraint { <generated::improbable::ComponentInterest_SphereConstraint as TypeConversion>::to_type(&data, &mut output.add_object(1))?; };
-        if let Some(ref data) = &input.cylinder_constraint { <generated::improbable::ComponentInterest_CylinderConstraint as TypeConversion>::to_type(&data, &mut output.add_object(2))?; };
-        if let Some(ref data) = &input.box_constraint { <generated::improbable::ComponentInterest_BoxConstraint as TypeConversion>::to_type(&data, &mut output.add_object(3))?; };
-        if let Some(ref data) = &input.relative_sphere_constraint { <generated::improbable::ComponentInterest_RelativeSphereConstraint as TypeConversion>::to_type(&data, &mut output.add_object(4))?; };
-        if let Some(ref data) = &input.relative_cylinder_constraint { <generated::improbable::ComponentInterest_RelativeCylinderConstraint as TypeConversion>::to_type(&data, &mut output.add_object(5))?; };
-        if let Some(ref data) = &input.relative_box_constraint { <generated::improbable::ComponentInterest_RelativeBoxConstraint as TypeConversion>::to_type(&data, &mut output.add_object(6))?; };
-        if let Some(data) = &input.entity_id_constraint { output.add::<SchemaInt64>(7, data); };
-        if let Some(data) = &input.component_constraint { output.add::<SchemaUint32>(8, data); };
-        for element in (&input.and_constraint).iter() { <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::to_type(&element, &mut output.add_object(9))?; };
-        for element in (&input.or_constraint).iter() { <generated::improbable::ComponentInterest_QueryConstraint as TypeConversion>::to_type(&element, &mut output.add_object(10))?; };
+        output.add::<Optional<generated::improbable::ComponentInterest_SphereConstraint>>(1, &input.sphere_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_CylinderConstraint>>(2, &input.cylinder_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_BoxConstraint>>(3, &input.box_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_RelativeSphereConstraint>>(4, &input.relative_sphere_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_RelativeCylinderConstraint>>(5, &input.relative_cylinder_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_RelativeBoxConstraint>>(6, &input.relative_box_constraint);
+        output.add::<Optional<SchemaInt64>>(7, &input.entity_id_constraint);
+        output.add::<Optional<SchemaUint32>>(8, &input.component_constraint);
+        output.add::<List<generated::improbable::ComponentInterest_QueryConstraint>>(9, &input.and_constraint);
+        output.add::<List<generated::improbable::ComponentInterest_QueryConstraint>>(10, &input.or_constraint);
         Ok(())
     }
 }
@@ -792,11 +792,11 @@ pub struct ComponentInterest_RelativeBoxConstraint {
 impl TypeConversion for ComponentInterest_RelativeBoxConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            edge_length: <generated::improbable::EdgeLength as TypeConversion>::from_type(&input.get_object(1))?,
+            edge_length: input.get::<generated::improbable::EdgeLength>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::EdgeLength as TypeConversion>::to_type(&&input.edge_length, &mut output.add_object(1))?;
+        output.add::<generated::improbable::EdgeLength>(1, &input.edge_length);
         Ok(())
     }
 }
@@ -841,12 +841,12 @@ pub struct ComponentInterest_SphereConstraint {
 impl TypeConversion for ComponentInterest_SphereConstraint {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            center: <generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?,
+            center: input.get::<generated::improbable::Coordinates>(1),
             radius: input.get::<SchemaDouble>(2),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::Coordinates as TypeConversion>::to_type(&&input.center, &mut output.add_object(1))?;
+        output.add::<generated::improbable::Coordinates>(1, &input.center);
         output.add::<SchemaDouble>(2, &input.radius);
         Ok(())
     }
@@ -903,11 +903,11 @@ pub struct WorkerAttributeSet {
 impl TypeConversion for WorkerAttributeSet {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            attribute: input.get_list::<SchemaString>(1),
+            attribute: input.get::<List<SchemaString>>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        output.add_list::<SchemaString>(1, &&input.attribute[..]);
+        output.add::<List<SchemaString>>(1, &input.attribute);
         Ok(())
     }
 }
@@ -919,11 +919,11 @@ pub struct WorkerRequirementSet {
 impl TypeConversion for WorkerRequirementSet {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            attribute_set: { let size = input.object_count(1); let mut l = Vec::with_capacity(size); for i in 0..size { l.push(<generated::improbable::WorkerAttributeSet as TypeConversion>::from_type(&input.index_object(1, i))?); } l },
+            attribute_set: input.get::<List<generated::improbable::WorkerAttributeSet>>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        for element in (&input.attribute_set).iter() { <generated::improbable::WorkerAttributeSet as TypeConversion>::to_type(&element, &mut output.add_object(1))?; };
+        output.add::<List<generated::improbable::WorkerAttributeSet>>(1, &input.attribute_set);
         Ok(())
     }
 }
@@ -937,12 +937,12 @@ pub struct EntityAcl {
 impl TypeConversion for EntityAcl {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            read_acl: <generated::improbable::WorkerRequirementSet as TypeConversion>::from_type(&input.get_object(1))?,
+            read_acl: input.get::<generated::improbable::WorkerRequirementSet>(1),
             component_write_acl: input.get::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::WorkerRequirementSet as TypeConversion>::to_type(&&input.read_acl, &mut output.add_object(1))?;
+        output.add::<generated::improbable::WorkerRequirementSet>(1, &input.read_acl);
         output.add::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2, &input.component_write_acl);
         Ok(())
     }
@@ -962,13 +962,13 @@ pub struct EntityAclUpdate {
 impl TypeConversion for EntityAclUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            read_acl: if input.object_count(1) > 0 { Some(<generated::improbable::WorkerRequirementSet as TypeConversion>::from_type(&input.get_object(1))?) } else { None },
+            read_acl: if input.object_count(1) > 0 { Some(input.get::<generated::improbable::WorkerRequirementSet>(1)) } else { None },
             component_write_acl: Some(input.get::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2)),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         if let Some(value) = &input.read_acl {
-            <generated::improbable::WorkerRequirementSet as TypeConversion>::to_type(&value, &mut output.add_object(1))?;
+            output.add::<generated::improbable::WorkerRequirementSet>(1, value);
         }
         if let Some(value) = &input.component_write_acl {
             output.add::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2, value);
@@ -1424,11 +1424,11 @@ pub struct Position {
 impl TypeConversion for Position {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            coords: <generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?,
+            coords: input.get::<generated::improbable::Coordinates>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::Coordinates as TypeConversion>::to_type(&&input.coords, &mut output.add_object(1))?;
+        output.add::<generated::improbable::Coordinates>(1, &input.coords);
         Ok(())
     }
 }
@@ -1445,12 +1445,12 @@ pub struct PositionUpdate {
 impl TypeConversion for PositionUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            coords: if input.object_count(1) > 0 { Some(<generated::improbable::Coordinates as TypeConversion>::from_type(&input.get_object(1))?) } else { None },
+            coords: if input.object_count(1) > 0 { Some(input.get::<generated::improbable::Coordinates>(1)) } else { None },
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         if let Some(value) = &input.coords {
-            <generated::improbable::Coordinates as TypeConversion>::to_type(&value, &mut output.add_object(1))?;
+            output.add::<generated::improbable::Coordinates>(1, value);
         }
         Ok(())
     }
@@ -1593,13 +1593,13 @@ pub struct Connection {
 impl TypeConversion for Connection {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            status: From::from(input.get::<SchemaEnum>(1)),
+            status: input.get::<generated::improbable::restricted::Connection_ConnectionStatus>(1),
             data_latency_ms: input.get::<SchemaUint32>(2),
             connected_since_utc: input.get::<SchemaUint64>(3),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        output.add::<SchemaEnum>(1, &&input.status.as_u32());
+        output.add::<generated::improbable::restricted::Connection_ConnectionStatus>(1, &input.status);
         output.add::<SchemaUint32>(2, &input.data_latency_ms);
         output.add::<SchemaUint64>(3, &input.connected_since_utc);
         Ok(())
@@ -1662,11 +1662,11 @@ pub struct PlayerClient {
 impl TypeConversion for PlayerClient {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            player_identity: <generated::improbable::restricted::PlayerIdentity as TypeConversion>::from_type(&input.get_object(1))?,
+            player_identity: input.get::<generated::improbable::restricted::PlayerIdentity>(1),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
-        <generated::improbable::restricted::PlayerIdentity as TypeConversion>::to_type(&&input.player_identity, &mut output.add_object(1))?;
+        output.add::<generated::improbable::restricted::PlayerIdentity>(1, &input.player_identity);
         Ok(())
     }
 }
@@ -1683,12 +1683,12 @@ pub struct PlayerClientUpdate {
 impl TypeConversion for PlayerClientUpdate {
     fn from_type(input: &SchemaObject) -> Result<Self, String> {
         Ok(Self {
-            player_identity: if input.object_count(1) > 0 { Some(<generated::improbable::restricted::PlayerIdentity as TypeConversion>::from_type(&input.get_object(1))?) } else { None },
+            player_identity: if input.object_count(1) > 0 { Some(input.get::<generated::improbable::restricted::PlayerIdentity>(1)) } else { None },
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         if let Some(value) = &input.player_identity {
-            <generated::improbable::restricted::PlayerIdentity as TypeConversion>::to_type(&value, &mut output.add_object(1))?;
+            output.add::<generated::improbable::restricted::PlayerIdentity>(1, value);
         }
         Ok(())
     }
@@ -1900,13 +1900,13 @@ impl TypeConversion for Worker {
         Ok(Self {
             worker_id: input.get::<SchemaString>(1),
             worker_type: input.get::<SchemaString>(2),
-            connection: <generated::improbable::restricted::Connection as TypeConversion>::from_type(&input.get_object(3))?,
+            connection: input.get::<generated::improbable::restricted::Connection>(3),
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
         output.add::<SchemaString>(1, &input.worker_id);
         output.add::<SchemaString>(2, &input.worker_type);
-        <generated::improbable::restricted::Connection as TypeConversion>::to_type(&&input.connection, &mut output.add_object(3))?;
+        output.add::<generated::improbable::restricted::Connection>(3, &input.connection);
         Ok(())
     }
 }
@@ -1929,7 +1929,7 @@ impl TypeConversion for WorkerUpdate {
         Ok(Self {
             worker_id: if input.count::<SchemaString>(1) > 0 { Some(input.get::<SchemaString>(1)) } else { None },
             worker_type: if input.count::<SchemaString>(2) > 0 { Some(input.get::<SchemaString>(2)) } else { None },
-            connection: if input.object_count(3) > 0 { Some(<generated::improbable::restricted::Connection as TypeConversion>::from_type(&input.get_object(3))?) } else { None },
+            connection: if input.object_count(3) > 0 { Some(input.get::<generated::improbable::restricted::Connection>(3)) } else { None },
         })
     }
     fn to_type(input: &Self, output: &mut SchemaObject) -> Result<(), String> {
@@ -1940,7 +1940,7 @@ impl TypeConversion for WorkerUpdate {
             output.add::<SchemaString>(2, value);
         }
         if let Some(value) = &input.connection {
-            <generated::improbable::restricted::Connection as TypeConversion>::to_type(&value, &mut output.add_object(3))?;
+            output.add::<generated::improbable::restricted::Connection>(3, value);
         }
         Ok(())
     }

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -8,7 +8,7 @@
 
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::generated as generated;
 
@@ -20,7 +20,7 @@ use super::generated as generated;
 pub mod example {
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::super::generated as generated;
 
@@ -32,19 +32,29 @@ pub enum TestEnum {
     SECOND,
 }
 
-impl From<u32> for TestEnum {
-    fn from(value: u32) -> Self {
-        match value {
+impl EnumField for TestEnum {}
 
-            0 => TestEnum::FIRST, 
-            1 => TestEnum::SECOND, 
-            _ => panic!(format!("Could not convert {} to enum TestEnum.", value))
+impl Default for TestEnum {
+    const fn default() -> Self {
+        TestEnum::FIRST
+    }
+}
+
+impl TryFrom<u32> for TestEnum {
+    type Error = UnknownDiscriminantError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            
+            0 => Ok(TestEnum::FIRST), 
+            1 => Ok(TestEnum::SECOND), 
+            _ => Error(UnknownDiscriminantError)
         }
     }
 }
 
-impl TestEnum {
-    pub(crate) fn as_u32(self) -> u32 {
+impl Into<u32> for TestEnum {
+    fn into(self) -> u32 {
         match self {
             
             TestEnum::FIRST => 0, 
@@ -52,6 +62,8 @@ impl TestEnum {
         }
     }
 }
+
+impl_field_for_enum_field!(TestEnum);
 
 /* Types. */
 #[derive(Debug, Clone)]
@@ -657,7 +669,7 @@ inventory::submit!(VTable::new::<Rotate>());
 pub mod improbable {
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::super::generated as generated;
 
@@ -1544,7 +1556,7 @@ inventory::submit!(VTable::new::<Position>());
 pub mod restricted {
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::super::super::generated as generated;
 
@@ -1558,21 +1570,31 @@ pub enum Connection_ConnectionStatus {
     DISCONNECTED,
 }
 
-impl From<u32> for Connection_ConnectionStatus {
-    fn from(value: u32) -> Self {
-        match value {
+impl EnumField for Connection_ConnectionStatus {}
 
-            0 => Connection_ConnectionStatus::UNKNOWN, 
-            1 => Connection_ConnectionStatus::AWAITING_WORKER_CONNECTION, 
-            2 => Connection_ConnectionStatus::CONNECTED, 
-            3 => Connection_ConnectionStatus::DISCONNECTED, 
-            _ => panic!(format!("Could not convert {} to enum Connection_ConnectionStatus.", value))
+impl Default for Connection_ConnectionStatus {
+    const fn default() -> Self {
+        Connection_ConnectionStatus::UNKNOWN
+    }
+}
+
+impl TryFrom<u32> for Connection_ConnectionStatus {
+    type Error = UnknownDiscriminantError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            
+            0 => Ok(Connection_ConnectionStatus::UNKNOWN), 
+            1 => Ok(Connection_ConnectionStatus::AWAITING_WORKER_CONNECTION), 
+            2 => Ok(Connection_ConnectionStatus::CONNECTED), 
+            3 => Ok(Connection_ConnectionStatus::DISCONNECTED), 
+            _ => Error(UnknownDiscriminantError)
         }
     }
 }
 
-impl Connection_ConnectionStatus {
-    pub(crate) fn as_u32(self) -> u32 {
+impl Into<u32> for Connection_ConnectionStatus {
+    fn into(self) -> u32 {
         match self {
             
             Connection_ConnectionStatus::UNKNOWN => 0, 
@@ -1582,6 +1604,8 @@ impl Connection_ConnectionStatus {
         }
     }
 }
+
+impl_field_for_enum_field!(Connection_ConnectionStatus);
 
 /* Types. */
 #[derive(Debug, Clone)]

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -77,7 +77,7 @@ impl ObjectField for CommandData {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaInt32>(1, &input.value);
+        output.add::<SchemaInt32>(1, &self.value);
     }
 }
 
@@ -92,7 +92,7 @@ impl ObjectField for TestType {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaInt32>(1, &input.value);
+        output.add::<SchemaInt32>(1, &self.value);
     }
 }
 
@@ -107,7 +107,7 @@ impl ObjectField for TestType_Inner {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaFloat>(2, &input.number);
+        output.add::<SchemaFloat>(2, &self.number);
     }
 }
 
@@ -126,9 +126,9 @@ impl ObjectField for Vector3d {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaDouble>(1, &input.x);
-        output.add::<SchemaDouble>(2, &input.y);
-        output.add::<SchemaDouble>(3, &input.z);
+        output.add::<SchemaDouble>(1, &self.x);
+        output.add::<SchemaDouble>(2, &self.y);
+        output.add::<SchemaDouble>(3, &self.z);
     }
 }
 
@@ -144,7 +144,7 @@ impl ObjectField for EntityIdTest {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaEntityId>(1, &input.eid);
+        output.add::<SchemaEntityId>(1, &self.eid);
     }
 }
 impl ComponentData<EntityIdTest> for EntityIdTest {
@@ -164,7 +164,7 @@ impl ObjectField for EntityIdTestUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.eid {
+        if let Some(value) = &self.eid {
             output.add::<SchemaEntityId>(1, value);
         }
     }
@@ -264,7 +264,7 @@ impl ObjectField for EnumTestComponent {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::example::TestEnum>(1, &input.test);
+        output.add::<generated::example::TestEnum>(1, &self.test);
     }
 }
 impl ComponentData<EnumTestComponent> for EnumTestComponent {
@@ -284,7 +284,7 @@ impl ObjectField for EnumTestComponentUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.test {
+        if let Some(value) = &self.test {
             output.add::<generated::example::TestEnum>(1, value);
         }
     }
@@ -384,7 +384,7 @@ impl ObjectField for Example {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaFloat>(1, &input.x);
+        output.add::<SchemaFloat>(1, &self.x);
     }
 }
 impl ComponentData<Example> for Example {
@@ -404,7 +404,7 @@ impl ObjectField for ExampleUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.x {
+        if let Some(value) = &self.x {
             output.add::<SchemaFloat>(1, value);
         }
     }
@@ -526,9 +526,9 @@ impl ObjectField for Rotate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaDouble>(1, &input.angle);
-        output.add::<generated::example::Vector3d>(2, &input.center);
-        output.add::<SchemaDouble>(3, &input.radius);
+        output.add::<SchemaDouble>(1, &self.angle);
+        output.add::<generated::example::Vector3d>(2, &self.center);
+        output.add::<SchemaDouble>(3, &self.radius);
     }
 }
 impl ComponentData<Rotate> for Rotate {
@@ -554,13 +554,13 @@ impl ObjectField for RotateUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.angle {
+        if let Some(value) = &self.angle {
             output.add::<SchemaDouble>(1, value);
         }
-        if let Some(value) = &input.center {
+        if let Some(value) = &self.center {
             output.add::<generated::example::Vector3d>(2, value);
         }
-        if let Some(value) = &input.radius {
+        if let Some(value) = &self.radius {
             output.add::<SchemaDouble>(3, value);
         }
     }
@@ -674,7 +674,7 @@ impl ObjectField for ComponentInterest {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<List<generated::improbable::ComponentInterest_Query>>(1, &input.queries);
+        output.add::<List<generated::improbable::ComponentInterest_Query>>(1, &self.queries);
     }
 }
 
@@ -691,8 +691,8 @@ impl ObjectField for ComponentInterest_BoxConstraint {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::Coordinates>(1, &input.center);
-        output.add::<generated::improbable::EdgeLength>(2, &input.edge_length);
+        output.add::<generated::improbable::Coordinates>(1, &self.center);
+        output.add::<generated::improbable::EdgeLength>(2, &self.edge_length);
     }
 }
 
@@ -709,8 +709,8 @@ impl ObjectField for ComponentInterest_CylinderConstraint {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::Coordinates>(1, &input.center);
-        output.add::<SchemaDouble>(2, &input.radius);
+        output.add::<generated::improbable::Coordinates>(1, &self.center);
+        output.add::<SchemaDouble>(2, &self.radius);
     }
 }
 
@@ -731,10 +731,10 @@ impl ObjectField for ComponentInterest_Query {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::ComponentInterest_QueryConstraint>(1, &input.constraint);
-        output.add::<Optional<SchemaBool>>(2, &input.full_snapshot_result);
-        output.add::<List<SchemaUint32>>(3, &input.result_component_id);
-        output.add::<Optional<SchemaFloat>>(4, &input.frequency);
+        output.add::<generated::improbable::ComponentInterest_QueryConstraint>(1, &self.constraint);
+        output.add::<Optional<SchemaBool>>(2, &self.full_snapshot_result);
+        output.add::<List<SchemaUint32>>(3, &self.result_component_id);
+        output.add::<Optional<SchemaFloat>>(4, &self.frequency);
     }
 }
 
@@ -767,16 +767,16 @@ impl ObjectField for ComponentInterest_QueryConstraint {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<Optional<generated::improbable::ComponentInterest_SphereConstraint>>(1, &input.sphere_constraint);
-        output.add::<Optional<generated::improbable::ComponentInterest_CylinderConstraint>>(2, &input.cylinder_constraint);
-        output.add::<Optional<generated::improbable::ComponentInterest_BoxConstraint>>(3, &input.box_constraint);
-        output.add::<Optional<generated::improbable::ComponentInterest_RelativeSphereConstraint>>(4, &input.relative_sphere_constraint);
-        output.add::<Optional<generated::improbable::ComponentInterest_RelativeCylinderConstraint>>(5, &input.relative_cylinder_constraint);
-        output.add::<Optional<generated::improbable::ComponentInterest_RelativeBoxConstraint>>(6, &input.relative_box_constraint);
-        output.add::<Optional<SchemaInt64>>(7, &input.entity_id_constraint);
-        output.add::<Optional<SchemaUint32>>(8, &input.component_constraint);
-        output.add::<List<generated::improbable::ComponentInterest_QueryConstraint>>(9, &input.and_constraint);
-        output.add::<List<generated::improbable::ComponentInterest_QueryConstraint>>(10, &input.or_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_SphereConstraint>>(1, &self.sphere_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_CylinderConstraint>>(2, &self.cylinder_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_BoxConstraint>>(3, &self.box_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_RelativeSphereConstraint>>(4, &self.relative_sphere_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_RelativeCylinderConstraint>>(5, &self.relative_cylinder_constraint);
+        output.add::<Optional<generated::improbable::ComponentInterest_RelativeBoxConstraint>>(6, &self.relative_box_constraint);
+        output.add::<Optional<SchemaInt64>>(7, &self.entity_id_constraint);
+        output.add::<Optional<SchemaUint32>>(8, &self.component_constraint);
+        output.add::<List<generated::improbable::ComponentInterest_QueryConstraint>>(9, &self.and_constraint);
+        output.add::<List<generated::improbable::ComponentInterest_QueryConstraint>>(10, &self.or_constraint);
     }
 }
 
@@ -791,7 +791,7 @@ impl ObjectField for ComponentInterest_RelativeBoxConstraint {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::EdgeLength>(1, &input.edge_length);
+        output.add::<generated::improbable::EdgeLength>(1, &self.edge_length);
     }
 }
 
@@ -806,7 +806,7 @@ impl ObjectField for ComponentInterest_RelativeCylinderConstraint {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaDouble>(1, &input.radius);
+        output.add::<SchemaDouble>(1, &self.radius);
     }
 }
 
@@ -821,7 +821,7 @@ impl ObjectField for ComponentInterest_RelativeSphereConstraint {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaDouble>(1, &input.radius);
+        output.add::<SchemaDouble>(1, &self.radius);
     }
 }
 
@@ -838,8 +838,8 @@ impl ObjectField for ComponentInterest_SphereConstraint {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::Coordinates>(1, &input.center);
-        output.add::<SchemaDouble>(2, &input.radius);
+        output.add::<generated::improbable::Coordinates>(1, &self.center);
+        output.add::<SchemaDouble>(2, &self.radius);
     }
 }
 
@@ -858,9 +858,9 @@ impl ObjectField for Coordinates {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaDouble>(1, &input.x);
-        output.add::<SchemaDouble>(2, &input.y);
-        output.add::<SchemaDouble>(3, &input.z);
+        output.add::<SchemaDouble>(1, &self.x);
+        output.add::<SchemaDouble>(2, &self.y);
+        output.add::<SchemaDouble>(3, &self.z);
     }
 }
 
@@ -879,9 +879,9 @@ impl ObjectField for EdgeLength {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaDouble>(1, &input.x);
-        output.add::<SchemaDouble>(2, &input.y);
-        output.add::<SchemaDouble>(3, &input.z);
+        output.add::<SchemaDouble>(1, &self.x);
+        output.add::<SchemaDouble>(2, &self.y);
+        output.add::<SchemaDouble>(3, &self.z);
     }
 }
 
@@ -896,7 +896,7 @@ impl ObjectField for WorkerAttributeSet {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<List<SchemaString>>(1, &input.attribute);
+        output.add::<List<SchemaString>>(1, &self.attribute);
     }
 }
 
@@ -911,7 +911,7 @@ impl ObjectField for WorkerRequirementSet {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<List<generated::improbable::WorkerAttributeSet>>(1, &input.attribute_set);
+        output.add::<List<generated::improbable::WorkerAttributeSet>>(1, &self.attribute_set);
     }
 }
 
@@ -929,8 +929,8 @@ impl ObjectField for EntityAcl {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::WorkerRequirementSet>(1, &input.read_acl);
-        output.add::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2, &input.component_write_acl);
+        output.add::<generated::improbable::WorkerRequirementSet>(1, &self.read_acl);
+        output.add::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2, &self.component_write_acl);
     }
 }
 impl ComponentData<EntityAcl> for EntityAcl {
@@ -953,10 +953,10 @@ impl ObjectField for EntityAclUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.read_acl {
+        if let Some(value) = &self.read_acl {
             output.add::<generated::improbable::WorkerRequirementSet>(1, value);
         }
-        if let Some(value) = &input.component_write_acl {
+        if let Some(value) = &self.component_write_acl {
             output.add::<Map<SchemaUint32, generated::improbable::WorkerRequirementSet>>(2, value);
         }
     }
@@ -1057,7 +1057,7 @@ impl ObjectField for Interest {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1, &input.component_interest);
+        output.add::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1, &self.component_interest);
     }
 }
 impl ComponentData<Interest> for Interest {
@@ -1077,7 +1077,7 @@ impl ObjectField for InterestUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.component_interest {
+        if let Some(value) = &self.component_interest {
             output.add::<Map<SchemaUint32, generated::improbable::ComponentInterest>>(1, value);
         }
     }
@@ -1177,7 +1177,7 @@ impl ObjectField for Metadata {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaString>(1, &input.entity_type);
+        output.add::<SchemaString>(1, &self.entity_type);
     }
 }
 impl ComponentData<Metadata> for Metadata {
@@ -1197,7 +1197,7 @@ impl ObjectField for MetadataUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.entity_type {
+        if let Some(value) = &self.entity_type {
             output.add::<SchemaString>(1, value);
         }
     }
@@ -1407,7 +1407,7 @@ impl ObjectField for Position {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::Coordinates>(1, &input.coords);
+        output.add::<generated::improbable::Coordinates>(1, &self.coords);
     }
 }
 impl ComponentData<Position> for Position {
@@ -1427,7 +1427,7 @@ impl ObjectField for PositionUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.coords {
+        if let Some(value) = &self.coords {
             output.add::<generated::improbable::Coordinates>(1, value);
         }
     }
@@ -1588,9 +1588,9 @@ impl ObjectField for Connection {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::restricted::Connection_ConnectionStatus>(1, &input.status);
-        output.add::<SchemaUint32>(2, &input.data_latency_ms);
-        output.add::<SchemaUint64>(3, &input.connected_since_utc);
+        output.add::<generated::improbable::restricted::Connection_ConnectionStatus>(1, &self.status);
+        output.add::<SchemaUint32>(2, &self.data_latency_ms);
+        output.add::<SchemaUint64>(3, &self.connected_since_utc);
     }
 }
 
@@ -1633,9 +1633,9 @@ impl ObjectField for PlayerIdentity {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaString>(1, &input.player_identifier);
-        output.add::<SchemaString>(2, &input.provider);
-        output.add::<SchemaBytes>(3, &input.metadata);
+        output.add::<SchemaString>(1, &self.player_identifier);
+        output.add::<SchemaString>(2, &self.provider);
+        output.add::<SchemaBytes>(3, &self.metadata);
     }
 }
 
@@ -1651,7 +1651,7 @@ impl ObjectField for PlayerClient {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<generated::improbable::restricted::PlayerIdentity>(1, &input.player_identity);
+        output.add::<generated::improbable::restricted::PlayerIdentity>(1, &self.player_identity);
     }
 }
 impl ComponentData<PlayerClient> for PlayerClient {
@@ -1671,7 +1671,7 @@ impl ObjectField for PlayerClientUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.player_identity {
+        if let Some(value) = &self.player_identity {
             output.add::<generated::improbable::restricted::PlayerIdentity>(1, value);
         }
     }
@@ -1885,9 +1885,9 @@ impl ObjectField for Worker {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        output.add::<SchemaString>(1, &input.worker_id);
-        output.add::<SchemaString>(2, &input.worker_type);
-        output.add::<generated::improbable::restricted::Connection>(3, &input.connection);
+        output.add::<SchemaString>(1, &self.worker_id);
+        output.add::<SchemaString>(2, &self.worker_type);
+        output.add::<generated::improbable::restricted::Connection>(3, &self.connection);
     }
 }
 impl ComponentData<Worker> for Worker {
@@ -1913,13 +1913,13 @@ impl ObjectField for WorkerUpdate {
         }
     }
     fn into_object(&self, output: &mut SchemaObject) {
-        if let Some(value) = &input.worker_id {
+        if let Some(value) = &self.worker_id {
             output.add::<SchemaString>(1, value);
         }
-        if let Some(value) = &input.worker_type {
+        if let Some(value) = &self.worker_type {
             output.add::<SchemaString>(2, value);
         }
-        if let Some(value) = &input.connection {
+        if let Some(value) = &self.connection {
             output.add::<generated::improbable::restricted::Connection>(3, value);
         }
     }

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -193,10 +193,6 @@ impl Component for EntityIdTest {
 
     const ID: ComponentId = 2001;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::example::EntityIdTest, String> {
-        Ok(<generated::example::EntityIdTest as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::EntityIdTestUpdate, String> {
         Ok(<generated::example::EntityIdTestUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -211,12 +207,6 @@ impl Component for EntityIdTest {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component EntityIdTest.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::example::EntityIdTest) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::example::EntityIdTest as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::EntityIdTestUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -313,10 +303,6 @@ impl Component for EnumTestComponent {
 
     const ID: ComponentId = 2002;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::example::EnumTestComponent, String> {
-        Ok(<generated::example::EnumTestComponent as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::EnumTestComponentUpdate, String> {
         Ok(<generated::example::EnumTestComponentUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -331,12 +317,6 @@ impl Component for EnumTestComponent {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component EnumTestComponent.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::example::EnumTestComponent) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::example::EnumTestComponent as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::EnumTestComponentUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -435,10 +415,6 @@ impl Component for Example {
 
     const ID: ComponentId = 1000;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::example::Example, String> {
-        Ok(<generated::example::Example as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::ExampleUpdate, String> {
         Ok(<generated::example::ExampleUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -461,12 +437,6 @@ impl Component for Example {
             },
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Example.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::example::Example) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::example::Example as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::ExampleUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -591,10 +561,6 @@ impl Component for Rotate {
 
     const ID: ComponentId = 1001;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::example::Rotate, String> {
-        Ok(<generated::example::Rotate as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::RotateUpdate, String> {
         Ok(<generated::example::RotateUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -609,12 +575,6 @@ impl Component for Rotate {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Rotate.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::example::Rotate) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::example::Rotate as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::RotateUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -986,10 +946,6 @@ impl Component for EntityAcl {
 
     const ID: ComponentId = 50;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::EntityAcl, String> {
-        Ok(<generated::improbable::EntityAcl as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::EntityAclUpdate, String> {
         Ok(<generated::improbable::EntityAclUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1004,12 +960,6 @@ impl Component for EntityAcl {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component EntityAcl.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::EntityAcl) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::EntityAcl as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::EntityAclUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -1106,10 +1056,6 @@ impl Component for Interest {
 
     const ID: ComponentId = 58;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Interest, String> {
-        Ok(<generated::improbable::Interest as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::InterestUpdate, String> {
         Ok(<generated::improbable::InterestUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1124,12 +1070,6 @@ impl Component for Interest {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Interest.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::Interest) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Interest as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::InterestUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -1226,10 +1166,6 @@ impl Component for Metadata {
 
     const ID: ComponentId = 53;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Metadata, String> {
-        Ok(<generated::improbable::Metadata as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::MetadataUpdate, String> {
         Ok(<generated::improbable::MetadataUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1244,12 +1180,6 @@ impl Component for Metadata {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Metadata.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::Metadata) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Metadata as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::MetadataUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -1336,10 +1266,6 @@ impl Component for Persistence {
 
     const ID: ComponentId = 55;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Persistence, String> {
-        Ok(<generated::improbable::Persistence as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::PersistenceUpdate, String> {
         Ok(<generated::improbable::PersistenceUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1354,12 +1280,6 @@ impl Component for Persistence {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Persistence.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::Persistence) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Persistence as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::PersistenceUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -1456,10 +1376,6 @@ impl Component for Position {
 
     const ID: ComponentId = 54;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Position, String> {
-        Ok(<generated::improbable::Position as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::PositionUpdate, String> {
         Ok(<generated::improbable::PositionUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1474,12 +1390,6 @@ impl Component for Position {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Position.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::Position) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Position as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::PositionUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -1703,10 +1613,6 @@ impl Component for PlayerClient {
 
     const ID: ComponentId = 61;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::restricted::PlayerClient, String> {
-        Ok(<generated::improbable::restricted::PlayerClient as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::restricted::PlayerClientUpdate, String> {
         Ok(<generated::improbable::restricted::PlayerClientUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1721,12 +1627,6 @@ impl Component for PlayerClient {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component PlayerClient.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::restricted::PlayerClient) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::restricted::PlayerClient as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::restricted::PlayerClientUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -1813,10 +1713,6 @@ impl Component for System {
 
     const ID: ComponentId = 59;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::restricted::System, String> {
-        Ok(<generated::improbable::restricted::System as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::restricted::SystemUpdate, String> {
         Ok(<generated::improbable::restricted::SystemUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1831,12 +1727,6 @@ impl Component for System {
         match command_index {
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component System.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::restricted::System) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::restricted::System as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::restricted::SystemUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
@@ -1955,10 +1845,6 @@ impl Component for Worker {
 
     const ID: ComponentId = 60;
 
-    fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::restricted::Worker, String> {
-        Ok(<generated::improbable::restricted::Worker as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::restricted::WorkerUpdate, String> {
         Ok(<generated::improbable::restricted::WorkerUpdate as ObjectField>::from_object(&update.fields()))
     }
@@ -1981,12 +1867,6 @@ impl Component for Worker {
             },
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Worker.", command_index))
         }
-    }
-
-    fn to_data(data: &generated::improbable::restricted::Worker) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::restricted::Worker as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::restricted::WorkerUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -191,11 +191,11 @@ impl Component for EntityIdTest {
     const ID: ComponentId = 2001;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::example::EntityIdTest, String> {
-        <generated::example::EntityIdTest as ObjectField>::from_object(&data.fields())
+        Ok(<generated::example::EntityIdTest as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::EntityIdTestUpdate, String> {
-        <generated::example::EntityIdTestUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::example::EntityIdTestUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::EntityIdTestCommandRequest, String> {
@@ -212,13 +212,13 @@ impl Component for EntityIdTest {
 
     fn to_data(data: &generated::example::EntityIdTest) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::example::EntityIdTest as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::example::EntityIdTest as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::EntityIdTestUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::example::EntityIdTestUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::example::EntityIdTestUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -311,11 +311,11 @@ impl Component for EnumTestComponent {
     const ID: ComponentId = 2002;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::example::EnumTestComponent, String> {
-        <generated::example::EnumTestComponent as ObjectField>::from_object(&data.fields())
+        Ok(<generated::example::EnumTestComponent as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::EnumTestComponentUpdate, String> {
-        <generated::example::EnumTestComponentUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::example::EnumTestComponentUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::EnumTestComponentCommandRequest, String> {
@@ -332,13 +332,13 @@ impl Component for EnumTestComponent {
 
     fn to_data(data: &generated::example::EnumTestComponent) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::example::EnumTestComponent as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::example::EnumTestComponent as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::EnumTestComponentUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::example::EnumTestComponentUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::example::EnumTestComponentUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -433,18 +433,18 @@ impl Component for Example {
     const ID: ComponentId = 1000;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::example::Example, String> {
-        <generated::example::Example as ObjectField>::from_object(&data.fields())
+        Ok(<generated::example::Example as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::ExampleUpdate, String> {
-        <generated::example::ExampleUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::example::ExampleUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::ExampleCommandRequest, String> {
         match command_index {
             1 => {
-                let result = <generated::example::CommandData as ObjectField>::from_object(&request.object());
-                result.and_then(|deserialized| Ok(ExampleCommandRequest::TestCommand(deserialized)))
+                let deserialized = <generated::example::CommandData as ObjectField>::from_object(&request.object());
+                Ok(ExampleCommandRequest::TestCommand(deserialized))
             },
             _ => Err(format!("Attempted to deserialize an unrecognised command request with index {} in component Example.", command_index))
         }
@@ -453,8 +453,8 @@ impl Component for Example {
     fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::example::ExampleCommandResponse, String> {
         match command_index {
             1 => {
-                let result = <generated::example::CommandData as ObjectField>::from_object(&response.object());
-                result.and_then(|deserialized| Ok(ExampleCommandResponse::TestCommand(deserialized)))
+                let deserialized = <generated::example::CommandData as ObjectField>::from_object(&response.object());
+                Ok(ExampleCommandResponse::TestCommand(deserialized))
             },
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Example.", command_index))
         }
@@ -462,13 +462,13 @@ impl Component for Example {
 
     fn to_data(data: &generated::example::Example) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::example::Example as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::example::Example as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::ExampleUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::example::ExampleUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::example::ExampleUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -476,7 +476,7 @@ impl Component for Example {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             ExampleCommandRequest::TestCommand(ref data) => {
-                <generated::example::CommandData as ObjectField>::into_object(data, &mut serialized_request.object_mut())?;
+                <generated::example::CommandData as ObjectField>::into_object(data, &mut serialized_request.object_mut());
             },
             _ => unreachable!()
         }
@@ -487,7 +487,7 @@ impl Component for Example {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             ExampleCommandResponse::TestCommand(ref data) => {
-                <generated::example::CommandData as ObjectField>::into_object(data, &mut serialized_response.object_mut())?;
+                <generated::example::CommandData as ObjectField>::into_object(data, &mut serialized_response.object_mut());
             },
             _ => unreachable!()
         }
@@ -589,11 +589,11 @@ impl Component for Rotate {
     const ID: ComponentId = 1001;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::example::Rotate, String> {
-        <generated::example::Rotate as ObjectField>::from_object(&data.fields())
+        Ok(<generated::example::Rotate as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::example::RotateUpdate, String> {
-        <generated::example::RotateUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::example::RotateUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::RotateCommandRequest, String> {
@@ -610,13 +610,13 @@ impl Component for Rotate {
 
     fn to_data(data: &generated::example::Rotate) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::example::Rotate as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::example::Rotate as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::example::RotateUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::example::RotateUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::example::RotateUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -984,11 +984,11 @@ impl Component for EntityAcl {
     const ID: ComponentId = 50;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::EntityAcl, String> {
-        <generated::improbable::EntityAcl as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::EntityAcl as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::EntityAclUpdate, String> {
-        <generated::improbable::EntityAclUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::EntityAclUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::EntityAclCommandRequest, String> {
@@ -1005,13 +1005,13 @@ impl Component for EntityAcl {
 
     fn to_data(data: &generated::improbable::EntityAcl) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::EntityAcl as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::EntityAcl as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::EntityAclUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::EntityAclUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::EntityAclUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1104,11 +1104,11 @@ impl Component for Interest {
     const ID: ComponentId = 58;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Interest, String> {
-        <generated::improbable::Interest as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::Interest as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::InterestUpdate, String> {
-        <generated::improbable::InterestUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::InterestUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::InterestCommandRequest, String> {
@@ -1125,13 +1125,13 @@ impl Component for Interest {
 
     fn to_data(data: &generated::improbable::Interest) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Interest as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::Interest as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::InterestUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::InterestUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::InterestUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1224,11 +1224,11 @@ impl Component for Metadata {
     const ID: ComponentId = 53;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Metadata, String> {
-        <generated::improbable::Metadata as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::Metadata as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::MetadataUpdate, String> {
-        <generated::improbable::MetadataUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::MetadataUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::MetadataCommandRequest, String> {
@@ -1245,13 +1245,13 @@ impl Component for Metadata {
 
     fn to_data(data: &generated::improbable::Metadata) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Metadata as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::Metadata as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::MetadataUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::MetadataUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::MetadataUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1334,11 +1334,11 @@ impl Component for Persistence {
     const ID: ComponentId = 55;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Persistence, String> {
-        <generated::improbable::Persistence as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::Persistence as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::PersistenceUpdate, String> {
-        <generated::improbable::PersistenceUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::PersistenceUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::PersistenceCommandRequest, String> {
@@ -1355,13 +1355,13 @@ impl Component for Persistence {
 
     fn to_data(data: &generated::improbable::Persistence) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Persistence as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::Persistence as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::PersistenceUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::PersistenceUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::PersistenceUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1454,11 +1454,11 @@ impl Component for Position {
     const ID: ComponentId = 54;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::Position, String> {
-        <generated::improbable::Position as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::Position as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::PositionUpdate, String> {
-        <generated::improbable::PositionUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::PositionUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::PositionCommandRequest, String> {
@@ -1475,13 +1475,13 @@ impl Component for Position {
 
     fn to_data(data: &generated::improbable::Position) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::Position as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::Position as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::PositionUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::PositionUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::PositionUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1698,11 +1698,11 @@ impl Component for PlayerClient {
     const ID: ComponentId = 61;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::restricted::PlayerClient, String> {
-        <generated::improbable::restricted::PlayerClient as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::restricted::PlayerClient as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::restricted::PlayerClientUpdate, String> {
-        <generated::improbable::restricted::PlayerClientUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::restricted::PlayerClientUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::restricted::PlayerClientCommandRequest, String> {
@@ -1719,13 +1719,13 @@ impl Component for PlayerClient {
 
     fn to_data(data: &generated::improbable::restricted::PlayerClient) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::restricted::PlayerClient as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::restricted::PlayerClient as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::restricted::PlayerClientUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::restricted::PlayerClientUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::restricted::PlayerClientUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1808,11 +1808,11 @@ impl Component for System {
     const ID: ComponentId = 59;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::restricted::System, String> {
-        <generated::improbable::restricted::System as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::restricted::System as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::restricted::SystemUpdate, String> {
-        <generated::improbable::restricted::SystemUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::restricted::SystemUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::restricted::SystemCommandRequest, String> {
@@ -1829,13 +1829,13 @@ impl Component for System {
 
     fn to_data(data: &generated::improbable::restricted::System) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::restricted::System as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::restricted::System as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::restricted::SystemUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::restricted::SystemUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::restricted::SystemUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1950,18 +1950,18 @@ impl Component for Worker {
     const ID: ComponentId = 60;
 
     fn from_data(data: &SchemaComponentData) -> Result<generated::improbable::restricted::Worker, String> {
-        <generated::improbable::restricted::Worker as ObjectField>::from_object(&data.fields())
+        Ok(<generated::improbable::restricted::Worker as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<generated::improbable::restricted::WorkerUpdate, String> {
-        <generated::improbable::restricted::WorkerUpdate as ObjectField>::from_object(&update.fields())
+        Ok(<generated::improbable::restricted::WorkerUpdate as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::restricted::WorkerCommandRequest, String> {
         match command_index {
             1 => {
-                let result = <generated::improbable::restricted::DisconnectRequest as ObjectField>::from_object(&request.object());
-                result.and_then(|deserialized| Ok(WorkerCommandRequest::Disconnect(deserialized)))
+                let deserialized = <generated::improbable::restricted::DisconnectRequest as ObjectField>::from_object(&request.object());
+                Ok(WorkerCommandRequest::Disconnect(deserialized))
             },
             _ => Err(format!("Attempted to deserialize an unrecognised command request with index {} in component Worker.", command_index))
         }
@@ -1970,8 +1970,8 @@ impl Component for Worker {
     fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::restricted::WorkerCommandResponse, String> {
         match command_index {
             1 => {
-                let result = <generated::improbable::restricted::DisconnectResponse as ObjectField>::from_object(&response.object());
-                result.and_then(|deserialized| Ok(WorkerCommandResponse::Disconnect(deserialized)))
+                let deserialized = <generated::improbable::restricted::DisconnectResponse as ObjectField>::from_object(&response.object());
+                Ok(WorkerCommandResponse::Disconnect(deserialized))
             },
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component Worker.", command_index))
         }
@@ -1979,13 +1979,13 @@ impl Component for Worker {
 
     fn to_data(data: &generated::improbable::restricted::Worker) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <generated::improbable::restricted::Worker as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <generated::improbable::restricted::Worker as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &generated::improbable::restricted::WorkerUpdate) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <generated::improbable::restricted::WorkerUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <generated::improbable::restricted::WorkerUpdate as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -1993,7 +1993,7 @@ impl Component for Worker {
         let mut serialized_request = SchemaCommandRequest::new();
         match request {
             WorkerCommandRequest::Disconnect(ref data) => {
-                <generated::improbable::restricted::DisconnectRequest as ObjectField>::into_object(data, &mut serialized_request.object_mut())?;
+                <generated::improbable::restricted::DisconnectRequest as ObjectField>::into_object(data, &mut serialized_request.object_mut());
             },
             _ => unreachable!()
         }
@@ -2004,7 +2004,7 @@ impl Component for Worker {
         let mut serialized_response = SchemaCommandResponse::new();
         match response {
             WorkerCommandResponse::Disconnect(ref data) => {
-                <generated::improbable::restricted::DisconnectResponse as ObjectField>::into_object(data, &mut serialized_response.object_mut())?;
+                <generated::improbable::restricted::DisconnectResponse as ObjectField>::into_object(data, &mut serialized_response.object_mut());
             },
             _ => unreachable!()
         }

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -63,7 +63,7 @@ impl ObjectField for <#= self.rust_name(&type_def.qualified_name) #> {
     fn into_object(&self, output: &mut SchemaObject) {<#
         for field in &type_def.fields {
         #>
-        <#= self.serialize_field(field, &format!("&input.{}", field.name), "output") #>;<# } #>
+        <#= self.serialize_field(field, &format!("&self.{}", field.name), "output") #>;<# } #>
     }
 }
 <# } #>
@@ -86,7 +86,7 @@ impl ObjectField for <#= self.rust_name(&component.qualified_name) #> {
     fn into_object(&self, output: &mut SchemaObject) {<#
         for field in &component_fields {
         #>
-        <#= self.serialize_field(field, &format!("&input.{}", field.name), "output") #>;<# } #>
+        <#= self.serialize_field(field, &format!("&self.{}", field.name), "output") #>;<# } #>
     }
 }
 impl ComponentData<<#= self.rust_name(&component.qualified_name) #>> for <#= self.rust_name(&component.qualified_name) #> {
@@ -113,7 +113,7 @@ impl ObjectField for <#= self.rust_name(&component.qualified_name) #>Update {
     fn into_object(&self, output: &mut SchemaObject) {<#
         for field in &component_fields {
         #>
-        if let Some(value) = &input.<#= field.name #> {
+        if let Some(value) = &self.<#= field.name #> {
             <#= self.serialize_field(field, "value", "output") #>;
         }<# } #>
     }

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -29,7 +29,10 @@ impl TryFrom<u32> for <#= enum_rust_name #> {
         match value {
             <# for enum_value in &enum_def.values { #>
             <#= enum_value.value #> => Ok(<#= enum_rust_name #>::<#= enum_value.name #>), <# } #>
-            _ => Err(UnknownDiscriminantError)
+            _ => Err(UnknownDiscriminantError {
+                type_name: std::any::type_name::<Self>(),
+                value,
+            }),
         }
     }
 }

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -148,11 +148,11 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
     const ID: ComponentId = <#= component.component_id #>;
 
     fn from_data(data: &SchemaComponentData) -> Result<<#= self.rust_fqname(&component.qualified_name) #>, String> {
-        <<#= self.rust_fqname(&component.qualified_name) #> as ObjectField>::from_object(&data.fields())
+        Ok(<<#= self.rust_fqname(&component.qualified_name) #> as ObjectField>::from_object(&data.fields()))
     }
 
     fn from_update(update: &SchemaComponentUpdate) -> Result<<#= self.rust_fqname(&component.qualified_name) #>Update, String> {
-        <<#= self.rust_fqname(&component.qualified_name) #>Update as ObjectField>::from_object(&update.fields())
+        Ok(<<#= self.rust_fqname(&component.qualified_name) #>Update as ObjectField>::from_object(&update.fields()))
     }
 
     fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<<#= self.rust_fqname(&component.qualified_name) #>CommandRequest, String> {
@@ -160,8 +160,8 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
             for command in &component.commands {
             #>
             <#= command.command_index #> => {
-                let result = <<#= self.rust_fqname(&command.request_type) #> as ObjectField>::from_object(&request.object());
-                result.and_then(|deserialized| Ok(<#= self.rust_name(&component.qualified_name) #>CommandRequest::<#= command.name.to_camel_case() #>(deserialized)))
+                let deserialized = <<#= self.rust_fqname(&command.request_type) #> as ObjectField>::from_object(&request.object());
+                Ok(<#= self.rust_name(&component.qualified_name) #>CommandRequest::<#= command.name.to_camel_case() #>(deserialized))
             },<# } #>
             _ => Err(format!("Attempted to deserialize an unrecognised command request with index {} in component <#= self.rust_name(&component.qualified_name) #>.", command_index))
         }
@@ -172,8 +172,8 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
             for command in &component.commands {
             #>
             <#= command.command_index #> => {
-                let result = <<#= self.rust_fqname(&command.response_type) #> as ObjectField>::from_object(&response.object());
-                result.and_then(|deserialized| Ok(<#= self.rust_name(&component.qualified_name) #>CommandResponse::<#= command.name.to_camel_case() #>(deserialized)))
+                let deserialized = <<#= self.rust_fqname(&command.response_type) #> as ObjectField>::from_object(&response.object());
+                Ok(<#= self.rust_name(&component.qualified_name) #>CommandResponse::<#= command.name.to_camel_case() #>(deserialized))
             },<# } #>
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component <#= self.rust_name(&component.qualified_name) #>.", command_index))
         }
@@ -181,13 +181,13 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
 
     fn to_data(data: &<#= self.rust_fqname(&component.qualified_name) #>) -> Result<Owned<SchemaComponentData>, String> {
         let mut serialized_data = SchemaComponentData::new();
-        <<#= self.rust_fqname(&component.qualified_name) #> as ObjectField>::into_object(data, &mut serialized_data.fields_mut())?;
+        <<#= self.rust_fqname(&component.qualified_name) #> as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
         Ok(serialized_data)
     }
 
     fn to_update(update: &<#= self.rust_fqname(&component.qualified_name) #>Update) -> Result<Owned<SchemaComponentUpdate>, String> {
         let mut serialized_update = SchemaComponentUpdate::new();
-        <<#= self.rust_fqname(&component.qualified_name) #>Update as ObjectField>::into_object(update, &mut serialized_update.fields_mut())?;
+        <<#= self.rust_fqname(&component.qualified_name) #>Update as ObjectField>::into_object(update, &mut serialized_update.fields_mut());
         Ok(serialized_update)
     }
 
@@ -197,7 +197,7 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
             for command in &component.commands {
             #>
             <#= self.rust_name(&component.qualified_name) #>CommandRequest::<#= command.name.to_camel_case() #>(ref data) => {
-                <<#= self.rust_fqname(&command.request_type) #> as ObjectField>::into_object(data, &mut serialized_request.object_mut())?;
+                <<#= self.rust_fqname(&command.request_type) #> as ObjectField>::into_object(data, &mut serialized_request.object_mut());
             },<# } #>
             _ => unreachable!()
         }
@@ -210,7 +210,7 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
             for command in &component.commands {
             #>
             <#= self.rust_name(&component.qualified_name) #>CommandResponse::<#= command.name.to_camel_case() #>(ref data) => {
-                <<#= self.rust_fqname(&command.response_type) #> as ObjectField>::into_object(data, &mut serialized_response.object_mut())?;
+                <<#= self.rust_fqname(&command.response_type) #> as ObjectField>::into_object(data, &mut serialized_response.object_mut());
             },<# } #>
             _ => unreachable!()
         }

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -150,10 +150,6 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
 
     const ID: ComponentId = <#= component.component_id #>;
 
-    fn from_data(data: &SchemaComponentData) -> Result<<#= self.rust_fqname(&component.qualified_name) #>, String> {
-        Ok(<<#= self.rust_fqname(&component.qualified_name) #> as ObjectField>::from_object(&data.fields()))
-    }
-
     fn from_update(update: &SchemaComponentUpdate) -> Result<<#= self.rust_fqname(&component.qualified_name) #>Update, String> {
         Ok(<<#= self.rust_fqname(&component.qualified_name) #>Update as ObjectField>::from_object(&update.fields()))
     }
@@ -180,12 +176,6 @@ impl Component for <#= self.rust_name(&component.qualified_name) #> {
             },<# } #>
             _ => Err(format!("Attempted to deserialize an unrecognised command response with index {} in component <#= self.rust_name(&component.qualified_name) #>.", command_index))
         }
-    }
-
-    fn to_data(data: &<#= self.rust_fqname(&component.qualified_name) #>) -> Result<Owned<SchemaComponentData>, String> {
-        let mut serialized_data = SchemaComponentData::new();
-        <<#= self.rust_fqname(&component.qualified_name) #> as ObjectField>::into_object(data, &mut serialized_data.fields_mut());
-        Ok(serialized_data)
     }
 
     fn to_update(update: &<#= self.rust_fqname(&component.qualified_name) #>Update) -> Result<Owned<SchemaComponentUpdate>, String> {

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
-fn get_rust_primitive_type_tag(primitive_type: &PrimitiveType) -> &'static str {
+fn primitive_type_name(primitive_type: &PrimitiveType) -> &'static str {
     match primitive_type {
         PrimitiveType::Invalid => panic!("Encountered invalid primitive."),
         PrimitiveType::Int32 => "SchemaInt32",
@@ -81,7 +81,7 @@ impl Package {
 
     fn schema_type_name(&self, type_ref: &TypeReference) -> Cow<'static, str> {
         match type_ref {
-            TypeReference::Primitive(prim) => get_rust_primitive_type_tag(prim).into(),
+            TypeReference::Primitive(prim) => primitive_type_name(prim).into(),
             TypeReference::Enum(name) => self.rust_fqname(name).into(),
             TypeReference::Type(name) => self.rust_fqname(name).into(),
         }

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -299,8 +299,8 @@ impl Package {
             TypeReference::Primitive(primitive) => format!(
                 "{}.count::<{}>({})",
                 schema_object,
-                get_rust_primitive_type_tag(primitive),
-                field_id
+                primitive_type_name(primitive),
+                field_id,
             ),
 
             TypeReference::Enum(_) => {

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -375,7 +375,7 @@ impl Package {
                 ref key_type,
                 ref value_type,
             } => format!(
-                "{}.get::<Map<{}, {}>>({})",
+                "Some({}.get::<Map<{}, {}>>({}))",
                 schema_field,
                 self.schema_type_name(key_type),
                 self.schema_type_name(value_type),

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -1,10 +1,11 @@
 use crate::schema_bundle::*;
 use heck::CamelCase;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
-fn get_rust_primitive_type_tag(primitive_type: &PrimitiveType) -> &str {
+fn get_rust_primitive_type_tag(primitive_type: &PrimitiveType) -> &'static str {
     match primitive_type {
         PrimitiveType::Invalid => panic!("Encountered invalid primitive."),
         PrimitiveType::Int32 => "SchemaInt32",
@@ -76,6 +77,40 @@ impl Package {
             identifier_package.rust_name(qualified_name),
         ]
         .join("::")
+    }
+
+    fn schema_type_name(&self, type_ref: &TypeReference) -> Cow<'static, str> {
+        match type_ref {
+            TypeReference::Primitive(prim) => get_rust_primitive_type_tag(prim).into(),
+            TypeReference::Enum(name) => self.rust_fqname(name).into(),
+            TypeReference::Type(name) => self.rust_fqname(name).into(),
+        }
+    }
+
+    fn field_type_name(&self, field_ty: &FieldDefinition_FieldType) -> Cow<'static, str> {
+        match field_ty {
+            FieldDefinition_FieldType::Singular { type_reference } => {
+                self.schema_type_name(type_reference)
+            }
+
+            FieldDefinition_FieldType::Option { inner_type } => {
+                format!("schema::Option<{}>", self.schema_type_name(inner_type)).into()
+            }
+
+            FieldDefinition_FieldType::List { inner_type } => {
+                format!("schema::List<{}>", self.schema_type_name(inner_type)).into()
+            }
+
+            FieldDefinition_FieldType::Map {
+                key_type,
+                value_type,
+            } => format!(
+                "schema::Map<{}, {}>",
+                self.schema_type_name(key_type),
+                self.schema_type_name(value_type),
+            )
+            .into(),
+        }
     }
 
     fn get_enum_definition(&self, qualified_name: &str) -> EnumDefinition {
@@ -205,6 +240,7 @@ impl Package {
             FieldDefinition_FieldType::Singular { ref type_reference } => {
                 self.serialize_type(field.field_id, type_reference, expression, schema_object)
             }
+
             FieldDefinition_FieldType::Option { ref inner_type } => {
                 let ref_decorator = if self.type_needs_borrow(inner_type) {
                     "ref "
@@ -218,6 +254,7 @@ impl Package {
                     self.serialize_type(field.field_id, inner_type, "data", schema_object)
                 )
             }
+
             FieldDefinition_FieldType::List { ref inner_type } => {
                 // If we have a list of primitives, we can just pass a slice directly to add_list.
                 match inner_type {
@@ -239,30 +276,18 @@ impl Package {
                     }
                 }
             }
+
             FieldDefinition_FieldType::Map {
                 ref key_type,
                 ref value_type,
-            } => {
-                let kvpair_object = format!(
-                    "let mut object = {}.add_object({})",
-                    schema_object, field.field_id
-                );
-                let serialize_key = self.serialize_type(1, key_type, "k", "object");
-                let serialize_value = self.serialize_type(
-                    2,
-                    value_type,
-                    if !self.type_needs_borrow(value_type) {
-                        "*v"
-                    } else {
-                        "v"
-                    },
-                    "object",
-                );
-                format!(
-                    "for (k, v) in {} {{ {}; {}; {}; }}",
-                    expression, kvpair_object, serialize_key, serialize_value
-                )
-            }
+            } => format!(
+                "{}.add::<Map<{}, {}>>({}, {})",
+                schema_object,
+                self.schema_type_name(key_type),
+                self.schema_type_name(value_type),
+                field.field_id,
+                expression,
+            ),
         }
     }
 
@@ -322,19 +347,13 @@ impl Package {
             FieldDefinition_FieldType::Map {
                 ref key_type,
                 ref value_type,
-            } => {
-                let capacity = format!("{}.object_count({})", schema_field, field.field_id);
-                let deserialize_key = self.deserialize_type(1, key_type, "kv");
-                let deserialize_value = self.deserialize_type(2, value_type, "kv");
-                format!(
-                    "{{ let size = {}; let mut m = BTreeMap::new(); for i in 0..size {{ let kv = {}.index_object({}, i); m.insert({}, {}); }}; m }}",
-                    capacity,
-                    schema_field,
-                    field.field_id,
-                    deserialize_key,
-                    deserialize_value,
-                )
-            }
+            } => format!(
+                "{}.get::<Map<{}, {}>>({})",
+                schema_field,
+                self.schema_type_name(key_type),
+                self.schema_type_name(value_type),
+                field.field_id
+            ),
         }
     }
 
@@ -355,19 +374,13 @@ impl Package {
             FieldDefinition_FieldType::Map {
                 ref key_type,
                 ref value_type,
-            } => {
-                let capacity = format!("{}.object_count({})", schema_field, field.field_id);
-                let deserialize_key = self.deserialize_type(1, key_type, "kv");
-                let deserialize_value = self.deserialize_type(2, value_type, "kv");
-                format!(
-                    "{{ let size = {}; if size > 0 {{ let mut m = BTreeMap::new(); for i in 0..size {{ let kv = {}.index_object({}, i); m.insert({}, {}); }} Some(m) }} else {{ None }} }}",
-                    capacity,
-                    schema_field,
-                    field.field_id,
-                    deserialize_key,
-                    deserialize_value,
-                )
-            }
+            } => format!(
+                "{}.get::<Map<{}, {}>>({})",
+                schema_field,
+                self.schema_type_name(key_type),
+                self.schema_type_name(value_type),
+                field.field_id
+            ),
         }
     }
 

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -130,18 +130,17 @@ impl<'a> ComponentDataRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the component impl `ObjectField` and `Clone`
+    // NOTE: We manually declare that the component impl `ObjectField`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
-    pub fn get<C: Component + ObjectField + Clone>(&self) -> Option<Cow<'_, C>> {
+    pub fn get<C: Component + ObjectField>(&self) -> Option<Cow<'_, C>> {
         if C::ID != self.component_id {
             return None;
         }
 
         let cow = if let Some(user_handle) = &self.user_handle {
-            let component = unsafe { &*user_handle.cast().as_ptr() };
-            Cow::Borrowed(component)
+            Cow::Borrowed(unsafe { &*user_handle.cast().as_ptr() })
         } else {
             Cow::Owned(ObjectField::from_object(self.schema_type.fields()))
         };
@@ -166,22 +165,21 @@ impl<'a> ComponentUpdateRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the update impl `ObjectField` and `Clone`
+    // NOTE: We manually declare that the update impl `ObjectField`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
     pub(crate) fn get<C>(&self) -> Option<Cow<'_, C::Update>>
     where
         C: Component,
-        C::Update: ObjectField + Clone,
+        C::Update: ObjectField,
     {
         if C::ID != self.component_id {
             return None;
         }
 
         let cow = if let Some(user_handle) = &self.user_handle {
-            let component = unsafe { &*user_handle.cast().as_ptr() };
-            Cow::Borrowed(component)
+            Cow::Borrowed(unsafe { &*user_handle.cast().as_ptr() })
         } else {
             Cow::Owned(ObjectField::from_object(self.schema_type.fields()))
         };
@@ -208,22 +206,21 @@ impl<'a> CommandRequestRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the update impl `ObjectField` and `Clone`
+    // NOTE: We manually declare that the request impl `ObjectField`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
     pub(crate) fn get<C>(&self) -> Option<Cow<'_, C::CommandRequest>>
     where
         C: Component,
-        C::CommandRequest: ObjectField + Clone,
+        C::CommandRequest: ObjectField,
     {
         if C::ID != self.component_id {
             return None;
         }
 
         let cow = if let Some(user_handle) = &self.user_handle {
-            let component = unsafe { &*user_handle.cast().as_ptr() };
-            Cow::Borrowed(component)
+            Cow::Borrowed(unsafe { &*user_handle.cast().as_ptr() })
         } else {
             Cow::Owned(ObjectField::from_object(self.schema_type.object()))
         };
@@ -250,22 +247,21 @@ impl<'a> CommandResponseRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the update impl `ObjectField` and `Clone`
+    // NOTE: We manually declare that the response impl `ObjectField`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
     pub fn get<C>(&self) -> Option<Cow<'_, C::CommandResponse>>
     where
         C: Component,
-        C::CommandResponse: ObjectField + Clone,
+        C::CommandResponse: ObjectField,
     {
         if C::ID != self.component_id {
             return None;
         }
 
         let cow = if let Some(user_handle) = &self.user_handle {
-            let component = unsafe { &*user_handle.cast().as_ptr() };
-            Cow::Borrowed(component)
+            Cow::Borrowed(unsafe { &*user_handle.cast().as_ptr() })
         } else {
             Cow::Owned(ObjectField::from_object(self.schema_type.object()))
         };

--- a/spatialos-sdk/src/worker/component.rs
+++ b/spatialos-sdk/src/worker/component.rs
@@ -19,15 +19,6 @@ pub trait ComponentData<C: Component> {
     fn merge(&mut self, update: C::Update);
 }
 
-// A trait that's implemented by a type to convert to/from schema objects.
-pub trait TypeConversion
-where
-    Self: std::marker::Sized,
-{
-    fn from_type(input: &schema::SchemaObject) -> Result<Self, String>;
-    fn to_type(input: &Self, output: &mut schema::SchemaObject) -> Result<(), String>;
-}
-
 // A trait that's implemented by a component to convert to/from schema handle types.
 pub trait Component
 where
@@ -139,23 +130,23 @@ impl<'a> ComponentDataRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the component impl `TypeConversion` and `Clone`
+    // NOTE: We manually declare that the component impl `ObjectField` and `Clone`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
-    pub fn get<C: Component + TypeConversion + Clone>(&self) -> Option<Cow<'_, C>> {
+    pub fn get<C: Component + ObjectField + Clone>(&self) -> Option<Cow<'_, C>> {
         if C::ID != self.component_id {
             return None;
         }
 
-        if let Some(user_handle) = &self.user_handle {
+        let cow = if let Some(user_handle) = &self.user_handle {
             let component = unsafe { &*user_handle.cast().as_ptr() };
-            Some(Cow::Borrowed(component))
+            Cow::Borrowed(component)
         } else {
-            TypeConversion::from_type(self.schema_type.fields())
-                .ok()
-                .map(Cow::Owned)
-        }
+            Cow::Owned(ObjectField::from_object(self.schema_type.fields()))
+        };
+
+        Some(cow)
     }
 }
 
@@ -175,27 +166,27 @@ impl<'a> ComponentUpdateRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the update impl `TypeConversion` and `Clone`
+    // NOTE: We manually declare that the update impl `ObjectField` and `Clone`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
     pub(crate) fn get<C>(&self) -> Option<Cow<'_, C::Update>>
     where
         C: Component,
-        C::Update: TypeConversion + Clone,
+        C::Update: ObjectField + Clone,
     {
         if C::ID != self.component_id {
             return None;
         }
 
-        if let Some(user_handle) = &self.user_handle {
+        let cow = if let Some(user_handle) = &self.user_handle {
             let component = unsafe { &*user_handle.cast().as_ptr() };
-            Some(Cow::Borrowed(component))
+            Cow::Borrowed(component)
         } else {
-            TypeConversion::from_type(self.schema_type.fields())
-                .ok()
-                .map(Cow::Owned)
-        }
+            Cow::Owned(ObjectField::from_object(self.schema_type.fields()))
+        };
+
+        Some(cow)
     }
 }
 
@@ -217,27 +208,27 @@ impl<'a> CommandRequestRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the update impl `TypeConversion` and `Clone`
+    // NOTE: We manually declare that the update impl `ObjectField` and `Clone`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
     pub(crate) fn get<C>(&self) -> Option<Cow<'_, C::CommandRequest>>
     where
         C: Component,
-        C::CommandRequest: TypeConversion + Clone,
+        C::CommandRequest: ObjectField + Clone,
     {
         if C::ID != self.component_id {
             return None;
         }
 
-        if let Some(user_handle) = &self.user_handle {
+        let cow = if let Some(user_handle) = &self.user_handle {
             let component = unsafe { &*user_handle.cast().as_ptr() };
-            Some(Cow::Borrowed(component))
+            Cow::Borrowed(component)
         } else {
-            TypeConversion::from_type(self.schema_type.object())
-                .ok()
-                .map(Cow::Owned)
-        }
+            Cow::Owned(ObjectField::from_object(self.schema_type.object()))
+        };
+
+        Some(cow)
     }
 }
 
@@ -259,27 +250,27 @@ impl<'a> CommandResponseRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the update impl `TypeConversion` and `Clone`
+    // NOTE: We manually declare that the update impl `ObjectField` and `Clone`
     // here, but in practice this will always be true for all component types. Future
     // iterations should clean this up such that the `Component` trait can imply these
     // other bounds automatically (i.e. by making them super traits of `Component`).
     pub fn get<C>(&self) -> Option<Cow<'_, C::CommandResponse>>
     where
         C: Component,
-        C::CommandResponse: TypeConversion + Clone,
+        C::CommandResponse: ObjectField + Clone,
     {
         if C::ID != self.component_id {
             return None;
         }
 
-        if let Some(user_handle) = &self.user_handle {
+        let cow = if let Some(user_handle) = &self.user_handle {
             let component = unsafe { &*user_handle.cast().as_ptr() };
-            Some(Cow::Borrowed(component))
+            Cow::Borrowed(component)
         } else {
-            TypeConversion::from_type(self.schema_type.object())
-                .ok()
-                .map(Cow::Owned)
-        }
+            Cow::Owned(ObjectField::from_object(self.schema_type.object()))
+        };
+
+        Some(cow)
     }
 }
 

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -541,7 +541,7 @@ pub struct AddComponentOp<'a> {
 impl<'a> AddComponentOp<'a> {
     pub fn get<C>(&self) -> Option<Cow<'_, C>>
     where
-        C: Component + ObjectField,
+        C: Component,
     {
         self.component_data.get::<C>()
     }

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -539,7 +539,10 @@ pub struct AddComponentOp<'a> {
 }
 
 impl<'a> AddComponentOp<'a> {
-    pub fn get<C: Component + ObjectField + Clone>(&self) -> Option<Cow<'_, C>> {
+    pub fn get<C>(&self) -> Option<Cow<'_, C>>
+    where
+        C: Component + ObjectField,
+    {
         self.component_data.get::<C>()
     }
 }
@@ -568,7 +571,7 @@ impl<'a> ComponentUpdateOp<'a> {
     pub fn get<C>(&self) -> Option<Cow<'_, C::Update>>
     where
         C: Component,
-        C::Update: ObjectField + Clone,
+        C::Update: ObjectField,
     {
         self.component_update.get::<C>()
     }
@@ -589,7 +592,7 @@ impl<'a> CommandRequestOp<'a> {
     pub fn get<C>(&self) -> Option<Cow<'_, C::CommandRequest>>
     where
         C: Component,
-        C::CommandRequest: ObjectField + Clone,
+        C::CommandRequest: ObjectField,
     {
         self.request.get::<C>()
     }

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -6,6 +6,7 @@ use crate::worker::{
     entity::Entity,
     internal::utils::*,
     metrics::Metrics,
+    schema::ObjectField,
     {Authority, EntityId, LogLevel, RequestId},
 };
 use spatialos_sdk_sys::worker::*;
@@ -538,7 +539,7 @@ pub struct AddComponentOp<'a> {
 }
 
 impl<'a> AddComponentOp<'a> {
-    pub fn get<C: Component + TypeConversion + Clone>(&self) -> Option<Cow<'_, C>> {
+    pub fn get<C: Component + ObjectField + Clone>(&self) -> Option<Cow<'_, C>> {
         self.component_data.get::<C>()
     }
 }
@@ -567,7 +568,7 @@ impl<'a> ComponentUpdateOp<'a> {
     pub fn get<C>(&self) -> Option<Cow<'_, C::Update>>
     where
         C: Component,
-        C::Update: TypeConversion + Clone,
+        C::Update: ObjectField + Clone,
     {
         self.component_update.get::<C>()
     }
@@ -588,7 +589,7 @@ impl<'a> CommandRequestOp<'a> {
     pub fn get<C>(&self) -> Option<Cow<'_, C::CommandRequest>>
     where
         C: Component,
-        C::CommandRequest: TypeConversion + Clone,
+        C::CommandRequest: ObjectField + Clone,
     {
         self.request.get::<C>()
     }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -56,7 +56,10 @@
 //! }
 //! ```
 
-use std::convert::TryFrom;
+use std::{
+    convert::TryFrom,
+    fmt::{self, Display, Formatter},
+};
 
 // NOTE: This module defines macros that are used in other submodules, so it must be
 // declared first in order for those macros to be visible to all sibling modules.
@@ -174,7 +177,20 @@ where
 
 /// The error type returned when a conversion to a schema enum type fails.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UnknownDiscriminantError;
+pub struct UnknownDiscriminantError {
+    pub type_name: &'static str,
+    pub value: u32,
+}
+
+impl Display for UnknownDiscriminantError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Found unknown discriminant value {} for enum `{}` while deserializing schema data",
+            self.value, self.type_name,
+        )
+    }
+}
 
 /// A type that corresponds to a [schemalang enumeration][schema-enum].
 ///

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -1,3 +1,61 @@
+//! Logic for serializing schema data.
+//!
+//! # Examples
+//!
+//! Serialization example using `Optional`:
+//!
+//! ```
+//! use spatialos_sdk::worker::schema::*;
+//!
+//! let mut data = SchemaComponentData::new();
+//! let object = data.fields_mut();
+//!
+//! let some_field = Some(123);
+//! let none_field = None;
+//!
+//! // Add the fields to the serialized data.
+//! object.add::<Optional<SchemaInt32>>(1, &some_field);
+//! object.add::<Optional<SchemaString>>(2, &none_field);
+//!
+//! // Get fields from serialized data.
+//! let some_result = object.get::<Optional<SchemaInt32>>(1);
+//! let none_result = object.get::<Optional<SchemaString>>(2);
+//!
+//! assert_eq!(some_field, some_result);
+//! assert_eq!(none_field, none_result);
+//! ```
+//!
+//! For the following schema type definition:
+//!
+//! ```schemalang,ignore
+//! type MyType {
+//!     option<int32> optional_value = 1;
+//! }
+//! ```
+//!
+//! The following code would be used to handle serialization:
+//!
+//! ```
+//! use spatialos_sdk::worker::schema::*;
+//!
+//! #[derive(Debug, Default, Clone)]
+//! pub struct MyType {
+//!     pub optional_value: Option<i32>,
+//! }
+//!
+//! impl ObjectField for MyType {
+//!     fn from_object(object: &SchemaObject) -> Self {
+//!         Self {
+//!             optional_value: object.get::<Optional<SchemaInt32>>(1),
+//!         }
+//!     }
+//!
+//!     fn into_object(&self, object: &mut SchemaObject) {
+//!         object.add::<Optional<SchemaInt32>>(1, &self.optional_value);
+//!     }
+//! }
+//! ```
+
 use std::convert::TryFrom;
 
 // NOTE: This module defines macros that are used in other submodules, so it must be

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -79,9 +79,9 @@ where
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct UnknownDiscriminantError;
+pub struct UnknownDiscriminantError;
 
-trait EnumField:
+pub trait EnumField:
     Sized + Clone + Copy + Default + TryFrom<u32, Error = UnknownDiscriminantError> + Into<u32>
 {
 }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -192,6 +192,8 @@ impl Display for UnknownDiscriminantError {
     }
 }
 
+impl std::error::Error for UnknownDiscriminantError {}
+
 /// A type that corresponds to a [schemalang enumeration][schema-enum].
 ///
 /// Schemalang enums are C-like enums (i.e. they only have a discriminant and do not

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -30,7 +30,12 @@ pub trait Field {
     fn index(object: &SchemaObject, field: FieldId, index: usize) -> Self::RustType;
     fn count(object: &SchemaObject, field: FieldId) -> usize;
     fn add(object: &mut SchemaObject, field: FieldId, value: &Self::RustType);
-    fn add_list(object: &mut SchemaObject, field: FieldId, value: &[Self::RustType]);
+
+    fn add_list(object: &mut SchemaObject, field: FieldId, values: &[Self::RustType]) {
+        for value in values {
+            Self::add(object, field, value);
+        }
+    }
 
     fn get_list(object: &SchemaObject, field: FieldId) -> Vec<Self::RustType> {
         let count = Self::count(object, field);

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -50,7 +50,7 @@ pub trait Field {
     }
 }
 
-pub trait ObjectField: Sized {
+pub trait ObjectField: Sized + Clone {
     fn from_object(object: &SchemaObject) -> Self;
     fn into_object(&self, object: &mut SchemaObject);
 }

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -4,6 +4,7 @@
 #[macro_use]
 mod macros;
 
+mod collections;
 mod command_request;
 mod command_response;
 mod component_data;
@@ -15,8 +16,8 @@ mod ptr;
 pub mod owned;
 
 pub use self::{
-    command_request::*, command_response::*, component_data::*, component_update::*, object::*,
-    owned::Owned, primitives::*,
+    collections::*, command_request::*, command_response::*, component_data::*,
+    component_update::*, object::*, owned::Owned, primitives::*,
 };
 
 pub(crate) use self::ptr::*;

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -23,7 +23,7 @@ pub(crate) use self::ptr::*;
 
 pub type FieldId = u32;
 
-pub trait SchemaPrimitiveField {
+pub trait Field {
     type RustType: Sized;
 
     fn get_or_default(object: &SchemaObject, field: FieldId) -> Self::RustType;

--- a/spatialos-sdk/src/worker/schema/collections.rs
+++ b/spatialos-sdk/src/worker/schema/collections.rs
@@ -117,8 +117,4 @@ where
     fn count(_object: &SchemaObject, _field: FieldId) -> usize {
         panic!("Map fields cannot be counted");
     }
-
-    fn add_list(_object: &mut SchemaObject, _field: FieldId, _value: &[Self::RustType]) {
-        panic!()
-    }
 }

--- a/spatialos-sdk/src/worker/schema/collections.rs
+++ b/spatialos-sdk/src/worker/schema/collections.rs
@@ -2,6 +2,17 @@ use crate::worker::schema::{Field, FieldId, SchemaObject};
 use spatialos_sdk_sys::worker::*;
 use std::{collections::BTreeMap, marker::PhantomData};
 
+/// Marker type corresponding to the [`option`] schemalang collection type.
+///
+/// `option<T>` is represented as [`Option<U>`][option] in the generated Rust code,
+/// where `U` is the Rust type corresponding to `T`. This type is named `Optional`
+/// instead of `Option` to avoid conflicting with Rust's built-in [`Option`][option]
+/// type.
+///
+/// See the [module-level documentation](index.html) for more information.
+///
+/// [`option`]: https://docs.improbable.io/reference/14.2/shared/schema/reference#collection-types
+/// [option]: https://doc.rust-lang.org/std/option/index.html
 pub struct Optional<T>(PhantomData<T>);
 
 impl<T> Field for Optional<T>
@@ -33,6 +44,15 @@ where
     }
 }
 
+/// Marker type corresponding to the [`list`] schemalang collection type.
+///
+/// `list<T>` is represented as [`Vec<U>`][vec] in the Rust code, where `U` is the Rust
+/// type corresponding to `T`.
+///
+/// See the [module-level documentation](index.html) for more information.
+///
+/// [`list`]: https://docs.improbable.io/reference/14.2/shared/schema/reference#collection-types
+/// [vec]: https://doc.rust-lang.org/std/vec/struct.Vec.html
 pub struct List<T>(PhantomData<T>);
 
 impl<T> Field for List<T>
@@ -66,6 +86,22 @@ where
     }
 }
 
+/// Marker type corresponding to the [`map`] schemalang collection type.
+///
+/// `map<K, V>` is represented as [`BTreeMap<T, U>`][btree] in the generated Rust
+/// code, where `T` is the Rust type corresponding to `K`, and `U` is the Rust type
+/// corresponding to `V`.
+///
+/// [`BTreeMap`][btree] is used instead of [`HashMap`] in order to provide
+/// deterministic ordering of values within the map. This allows the underlying
+/// serialization library to generate smaller diffs when sending updates of schema
+/// data containing a `map`.
+///
+/// See the [module-level documentation](index.html) for more information.
+///
+/// [`map`]: https://docs.improbable.io/reference/14.2/shared/schema/reference#collection-types
+/// [btree]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
+/// [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 pub struct Map<K, V>(PhantomData<(K, V)>);
 
 impl<K, V> Field for Map<K, V>

--- a/spatialos-sdk/src/worker/schema/collections.rs
+++ b/spatialos-sdk/src/worker/schema/collections.rs
@@ -1,0 +1,61 @@
+use crate::worker::schema::{Field, FieldId, SchemaObject};
+use spatialos_sdk_sys::worker::*;
+use std::{collections::BTreeMap, marker::PhantomData};
+
+#[derive(Debug)]
+pub struct Map<K, V>(PhantomData<(K, V)>);
+
+impl<K, V> Field for Map<K, V>
+where
+    K: Field,
+    V: Field,
+    K::RustType: Ord,
+{
+    type RustType = BTreeMap<K::RustType, V::RustType>;
+
+    fn get_or_default(object: &SchemaObject, field: FieldId) -> Self::RustType {
+        let mut result = BTreeMap::new();
+
+        // Load each of the key-value pairs from the map object.
+        //
+        // Map fields are represented in schema as a list of pairs of key and value. Each
+        // entry in the map is an object field with field ID corresponding to the map's
+        // field ID, and each object should have a key field with ID `SCHEMA_MAP_KEY_FIELD_ID`
+        // and a value field with ID `SCHEMA_MAP_VALUE_FIELD_ID`.
+        let count = object.object_count(field);
+        for index in 0..count {
+            let pair = object.index_object(field, index);
+            let key = K::get_or_default(&pair, SCHEMA_MAP_KEY_FIELD_ID);
+            let value = V::get_or_default(&pair, SCHEMA_MAP_VALUE_FIELD_ID);
+            result.insert(key, value);
+        }
+
+        result
+    }
+
+    fn add(object: &mut SchemaObject, field: FieldId, map: &Self::RustType) {
+        // Create a key-value pair object for each entry in the map.
+        //
+        // Map fields are represented in schema as a list of pairs of key and value. Each
+        // entry in the map is an object field with field ID corresponding to the map's
+        // field ID, and each object should have a key field with ID `SCHEMA_MAP_KEY_FIELD_ID`
+        // and a value field with ID `SCHEMA_MAP_VALUE_FIELD_ID`.
+        for (key, value) in map {
+            let pair = object.add_object(field);
+            pair.add::<K>(SCHEMA_MAP_KEY_FIELD_ID, key);
+            pair.add::<V>(SCHEMA_MAP_VALUE_FIELD_ID, value);
+        }
+    }
+
+    fn index(_object: &SchemaObject, _field: FieldId, _index: usize) -> Self::RustType {
+        panic!("Map fields cannot be indexed into");
+    }
+
+    fn count(_object: &SchemaObject, _field: FieldId) -> usize {
+        panic!("Map fields cannot be counted");
+    }
+
+    fn add_list(_object: &mut SchemaObject, _field: FieldId, _value: &[Self::RustType]) {
+        panic!()
+    }
+}

--- a/spatialos-sdk/src/worker/schema/component_data.rs
+++ b/spatialos-sdk/src/worker/schema/component_data.rs
@@ -1,4 +1,7 @@
-use crate::worker::schema::{DataPointer, Owned, OwnedPointer, SchemaObject};
+use crate::worker::{
+    component::Component,
+    schema::{DataPointer, Owned, OwnedPointer, SchemaObject},
+};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -12,8 +15,18 @@ use std::marker::PhantomData;
 pub struct SchemaComponentData(PhantomData<*mut Schema_ComponentData>);
 
 impl SchemaComponentData {
-    pub fn new() -> Owned<SchemaComponentData> {
+    pub fn new() -> Owned<Self> {
         Owned::new()
+    }
+
+    pub fn from_component<C: Component>(component: &C) -> Owned<Self> {
+        let mut result = Self::new();
+        component.into_object(result.fields_mut());
+        result
+    }
+
+    pub fn deserialize<C: Component>(&self) -> C {
+        C::from_object(self.fields())
     }
 
     pub fn fields(&self) -> &SchemaObject {

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -1,4 +1,4 @@
-use crate::worker::schema::{DataPointer, FieldId, SchemaPrimitiveField};
+use crate::worker::schema::{DataPointer, Field, FieldId};
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -6,27 +6,27 @@ use std::marker::PhantomData;
 pub struct SchemaObject(PhantomData<*mut Schema_Object>);
 
 impl SchemaObject {
-    pub fn get<T: SchemaPrimitiveField>(&self, field: FieldId) -> T::RustType {
+    pub fn get<T: Field>(&self, field: FieldId) -> T::RustType {
         T::get_or_default(self, field)
     }
 
-    pub fn get_index<T: SchemaPrimitiveField>(&self, field: FieldId, index: usize) -> T::RustType {
+    pub fn get_index<T: Field>(&self, field: FieldId, index: usize) -> T::RustType {
         T::index(self, field, index)
     }
 
-    pub fn count<T: SchemaPrimitiveField>(&self, field: FieldId) -> usize {
+    pub fn count<T: Field>(&self, field: FieldId) -> usize {
         T::count(self, field)
     }
 
-    pub fn add<T: SchemaPrimitiveField>(&mut self, field: FieldId, value: &T::RustType) {
+    pub fn add<T: Field>(&mut self, field: FieldId, value: &T::RustType) {
         T::add(self, field, value);
     }
 
-    pub fn get_list<T: SchemaPrimitiveField>(&self, field: FieldId) -> Vec<T::RustType> {
+    pub fn get_list<T: Field>(&self, field: FieldId) -> Vec<T::RustType> {
         T::get_list(self, field)
     }
 
-    pub fn add_list<T: SchemaPrimitiveField>(&mut self, field: FieldId, value: &[T::RustType]) {
+    pub fn add_list<T: Field>(&mut self, field: FieldId, value: &[T::RustType]) {
         T::add_list(self, field, value);
     }
 

--- a/spatialos-sdk/src/worker/schema/primitives.rs
+++ b/spatialos-sdk/src/worker/schema/primitives.rs
@@ -1,5 +1,5 @@
 use crate::worker::{
-    schema::{DataPointer, FieldId, SchemaObject, SchemaPrimitiveField},
+    schema::{DataPointer, Field, FieldId, SchemaObject},
     EntityId,
 };
 use spatialos_sdk_sys::worker::*;
@@ -18,7 +18,7 @@ macro_rules! impl_primitive_field {
         #[derive(Debug)]
         pub struct $schema_type;
 
-        impl SchemaPrimitiveField for $schema_type {
+        impl Field for $schema_type {
             type RustType = $rust_type;
 
             fn get_or_default(object: &SchemaObject, field: FieldId) -> $rust_type {
@@ -180,7 +180,7 @@ pub struct SchemaBytes;
 #[derive(Debug)]
 pub struct SchemaString;
 
-impl SchemaPrimitiveField for SchemaEntityId {
+impl Field for SchemaEntityId {
     type RustType = EntityId;
 
     fn get_or_default(object: &SchemaObject, field: FieldId) -> EntityId {
@@ -210,7 +210,7 @@ impl SchemaPrimitiveField for SchemaEntityId {
     }
 }
 
-impl SchemaPrimitiveField for SchemaBool {
+impl Field for SchemaBool {
     type RustType = bool;
 
     fn get_or_default(object: &SchemaObject, field: FieldId) -> bool {
@@ -240,7 +240,7 @@ impl SchemaPrimitiveField for SchemaBool {
     }
 }
 
-impl SchemaPrimitiveField for SchemaString {
+impl Field for SchemaString {
     type RustType = String;
 
     fn get_or_default(object: &SchemaObject, field: FieldId) -> String {
@@ -284,7 +284,7 @@ impl SchemaPrimitiveField for SchemaString {
     }
 }
 
-impl SchemaPrimitiveField for SchemaBytes {
+impl Field for SchemaBytes {
     type RustType = Vec<u8>;
 
     fn get_or_default(object: &SchemaObject, field: FieldId) -> Vec<u8> {


### PR DESCRIPTION
> Part of #121 

This PR unifies how schema data serialization is handled, specifically allowing collection types and user-defined types (struct types and enums) to be serialized via the same mechanism as primitive types. This allows us to drastically simplify the serialization code generated for schema-defined types.

* Rename `SchemaPrimitiveField` to `Field` now that it is used for all field types and not just primitives.
* Remove `component::TypeConversion` trait and replace it with `schema::ObjectField` trait. This trait functions largely the same as before, but function names have been changed and functions no longer return `Result`s.
* Add a blanket impl of `Field` for all types implementing `ObjectField`. This ensures we only have to generate code for the simpler `ObjectField` trait, and can serialize object fields in the same manner as primitive fields.
* Add `EnumField` trait and `impl_field_for_enum_field!` helper macro to simulate a blanket impl of `Field` for types implementing `EnumField`. Rust's coherence rules prevent us from directly providing such a blanket impl, as noted in the comments.
* Use `TryFrom` to avoid panicking if deserializing an enum from an unknown discriminant value.
* Add `schema::collections` module with marker types `Optional<T>`, `List<T>`, and `Map<K, V>`. These marker types implement `Field` so that schema collection types can be serialized in the same manner as primitive fields.
* Update code generation accordingly. It's much simpler now!

The most complex part of the code generation at this point is handling component updates, since the generated code still has to check to see if the field is present in the update or not. This also means that collection types aren't handling being cleared correctly. This will be fixed in the next PR.