### PR TITLE
Upgrade to Rust 1.39 + use new futures

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -17,9 +17,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: "1.39.0"
-
-      - name: Install Rust components
-        run: rustup component add rustfmt clippy
+          default: true
+          components: rustfmt, clippy
 
       - name: Install spatial
         uses: jamiebrynes7/get-spatial-cli-action@v1.1

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -14,10 +14,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Install Rust
-        if: matrix.os == 'macOS-latest'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.39.0"
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SpatialOS SDK for Rust
 
-[![Build Status](https://travis-ci.org/jamiebrynes7/spatialos-sdk-rs.svg?branch=master)](https://travis-ci.org/jamiebrynes7/spatialos-sdk-rs) [![dependency status](https://deps.rs/repo/github/jamiebrynes7/spatialos-sdk-rs/status.svg)](https://deps.rs/repo/github/jamiebrynes7/spatialos-sdk-rs) ![Rustc Version](https://img.shields.io/badge/rustc-1.38-blue.svg)
+[![Build Status](https://travis-ci.org/jamiebrynes7/spatialos-sdk-rs.svg?branch=master)](https://travis-ci.org/jamiebrynes7/spatialos-sdk-rs) [![dependency status](https://deps.rs/repo/github/jamiebrynes7/spatialos-sdk-rs/status.svg)](https://deps.rs/repo/github/jamiebrynes7/spatialos-sdk-rs) ![Rustc Version](https://img.shields.io/badge/rustc-1.39-blue.svg)
 
 
 > This is an **unofficial**, **unsupported**, and **untested** integration of the [SpatialOS SDK C API bindings](https://docs.improbable.io/reference/13.3/capi/introduction) with Rust. Improbable does not officially support Rust as a worker language.
 
 ## Requirements
 
-1. Rust v1.38
+1. Rust v1.39
 2. A [SpatialOS account](https://www.improbable.io/get-spatialos) 
 
 ## Setup

--- a/project-example/Cargo.toml
+++ b/project-example/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 spatialos-sdk = { path = "../spatialos-sdk"}
-futures = "0.1.25"
+futures = "0.3.1"
 uuid = { version = "0.8", features = ["v4"] }
 structopt = "0.3"
 rand = "0.7"

--- a/project-example/src/connection_handler.rs
+++ b/project-example/src/connection_handler.rs
@@ -1,6 +1,6 @@
 use crate::{Command, Opt};
 use spatialos_sdk::worker::{
-    connection::{WorkerConnection},
+    connection::WorkerConnection,
     constants::{LOCATOR_HOSTNAME, LOCATOR_PORT, RECEPTIONIST_PORT},
     locator::{
         Locator, LocatorParameters, LoginTokensRequest, PlayerIdentityCredentials,
@@ -8,8 +8,8 @@ use spatialos_sdk::worker::{
     },
     parameters::ConnectionParameters,
 };
-use uuid::Uuid;
 use std::error::Error;
+use uuid::Uuid;
 
 pub async fn get_connection(opt: Opt) -> Result<WorkerConnection, Box<dyn Error>> {
     let Opt {
@@ -65,25 +65,21 @@ pub async fn get_connection(opt: Opt) -> Result<WorkerConnection, Box<dyn Error>
                 LOCATOR_HOSTNAME,
                 LOCATOR_PORT,
                 request,
-            ).await?;
+            )
+            .await?;
 
-            let request =
-                LoginTokensRequest::new(pit.player_identity_token.as_str(), worker_type.as_str());
-            let response = Locator::create_development_login_tokens(
-                LOCATOR_HOSTNAME,
-                LOCATOR_PORT,
-                request,
-            ).await?;
+            let request = LoginTokensRequest::new(&pit.player_identity_token, &worker_type);
+            let response =
+                Locator::create_development_login_tokens(LOCATOR_HOSTNAME, LOCATOR_PORT, request)
+                    .await?;
 
             if response.login_tokens.is_empty() {
                 return Err("No login tokens retrieved".into());
             }
 
             let token = &response.login_tokens[0];
-            let credentials = PlayerIdentityCredentials::new(
-                pit.player_identity_token.as_str(),
-                token.login_token.as_str(),
-            );
+            let credentials =
+                PlayerIdentityCredentials::new(&pit.player_identity_token, &token.login_token);
             let locator = Locator::new(
                 LOCATOR_HOSTNAME,
                 LOCATOR_PORT,

--- a/project-example/src/connection_handler.rs
+++ b/project-example/src/connection_handler.rs
@@ -1,7 +1,6 @@
 use crate::{Command, Opt};
-use futures::{Async, Future};
 use spatialos_sdk::worker::{
-    connection::{WorkerConnection, WorkerConnectionFuture},
+    connection::{WorkerConnection},
     constants::{LOCATOR_HOSTNAME, LOCATOR_PORT, RECEPTIONIST_PORT},
     locator::{
         Locator, LocatorParameters, LoginTokensRequest, PlayerIdentityCredentials,
@@ -10,20 +9,17 @@ use spatialos_sdk::worker::{
     parameters::ConnectionParameters,
 };
 use uuid::Uuid;
+use std::error::Error;
 
-const POLL_NUM_ATTEMPTS: u32 = 5;
-const POLL_TIME_BETWEEN_ATTEMPTS_MILLIS: u64 = 3000;
-
-pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
+pub async fn get_connection(opt: Opt) -> Result<WorkerConnection, Box<dyn Error>> {
     let Opt {
         worker_type,
         worker_id,
-        connect_with_poll,
         command,
     } = opt;
 
     let worker_id = worker_id.unwrap_or_else(|| format!("{}-{}", &worker_type, Uuid::new_v4()));
-    let mut future = match command {
+    let future = match command {
         Command::Receptionist {
             host,
             port,
@@ -33,11 +29,11 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
                 .using_udp()
                 .using_external_ip(connect_with_external_ip)
                 .enable_internal_serialization();
-            WorkerConnection::connect_receptionist_async(
+            WorkerConnection::connect_receptionist(
                 &worker_id,
                 &host.unwrap_or_else(|| "127.0.0.1".into()),
                 port.unwrap_or(RECEPTIONIST_PORT),
-                &params,
+                params,
             )
         }
 
@@ -53,9 +49,9 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
                     login_token,
                 )),
             );
-            WorkerConnection::connect_locator_async(
-                &locator,
-                &ConnectionParameters::new(worker_type)
+            WorkerConnection::connect_locator(
+                locator,
+                ConnectionParameters::new(worker_type)
                     .using_tcp()
                     .using_external_ip(true)
                     .enable_internal_serialization(),
@@ -63,27 +59,24 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
         }
 
         Command::DevelopmentAuthentication { dev_auth_token } => {
-            let mut request = PlayerIdentityTokenRequest::new(dev_auth_token, "player-id")
+            let request = PlayerIdentityTokenRequest::new(dev_auth_token, "player-id")
                 .with_display_name("My Player");
-            let future = Locator::create_development_player_identity_token(
+            let pit = Locator::create_development_player_identity_token(
                 LOCATOR_HOSTNAME,
                 LOCATOR_PORT,
-                &mut request,
-            );
+                request,
+            ).await?;
 
-            let pit = future.wait()?;
-            let mut request =
+            let request =
                 LoginTokensRequest::new(pit.player_identity_token.as_str(), worker_type.as_str());
-            let future = Locator::create_development_login_tokens(
+            let response = Locator::create_development_login_tokens(
                 LOCATOR_HOSTNAME,
                 LOCATOR_PORT,
-                &mut request,
-            );
-
-            let response = future.wait()?;
+                request,
+            ).await?;
 
             if response.login_tokens.is_empty() {
-                return Err("No login tokens retrieved".to_owned());
+                return Err("No login tokens retrieved".into());
             }
 
             let token = &response.login_tokens[0];
@@ -97,9 +90,9 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
                 &LocatorParameters::new(credentials),
             );
 
-            WorkerConnection::connect_locator_async(
-                &locator,
-                &ConnectionParameters::new(worker_type)
+            WorkerConnection::connect_locator(
+                locator,
+                ConnectionParameters::new(worker_type)
                     .using_tcp()
                     .using_external_ip(true)
                     .enable_internal_serialization(),
@@ -107,29 +100,5 @@ pub fn get_connection(opt: Opt) -> Result<WorkerConnection, String> {
         }
     };
 
-    if connect_with_poll {
-        get_connection_poll(&mut future)
-    } else {
-        future.wait()
-    }
-}
-
-fn get_connection_poll(future: &mut WorkerConnectionFuture) -> Result<WorkerConnection, String> {
-    for _ in 0..POLL_NUM_ATTEMPTS {
-        println!("Attempting to poll.");
-        match future.poll() {
-            Ok(res) => {
-                if let Async::Ready(conn) = res {
-                    return Ok(conn);
-                }
-            }
-            Err(s) => return Err(s),
-        };
-
-        ::std::thread::sleep(::std::time::Duration::from_millis(
-            POLL_TIME_BETWEEN_ATTEMPTS_MILLIS,
-        ));
-    }
-
-    Err("Max connection attempts failed.".to_owned())
+    Ok(future.await?)
 }

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -1,4 +1,10 @@
+mod connection_handler;
+#[rustfmt::skip]
+mod generated;
+mod opt;
+
 use crate::{connection_handler::*, opt::*};
+use futures::executor::block_on;
 use generated::{example, improbable};
 use rand::Rng;
 use spatialos_sdk::worker::{
@@ -14,14 +20,9 @@ use spatialos_sdk::worker::{
 use std::{collections::HashMap, f64};
 use structopt::StructOpt;
 
-mod connection_handler;
-#[rustfmt::skip]
-mod generated;
-mod opt;
-
 fn main() {
     let opt = Opt::from_args();
-    let mut worker_connection = match get_connection(opt) {
+    let mut worker_connection = match block_on(get_connection(opt)) {
         Ok(c) => c,
         Err(e) => panic!("{}", e),
     };

--- a/project-example/src/opt.rs
+++ b/project-example/src/opt.rs
@@ -12,9 +12,6 @@ pub struct Opt {
     #[structopt(name = "WORKER_ID", long, short = "i")]
     pub worker_id: Option<String>,
 
-    #[structopt(name = "POLLING_CONNECTION", long = "polling-connection", short = "p")]
-    pub connect_with_poll: bool,
-
     #[structopt(subcommand)]
     pub command: Command,
 }

--- a/project-example/src/opt.rs
+++ b/project-example/src/opt.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 #[structopt(
     name = "project-example",
     about = "A SpatialOS worker written in Rust.",
-    rename_all="kebab-case"
+    rename_all = "kebab-case"
 )]
 pub struct Opt {
     #[structopt(long, short = "i")]

--- a/project-example/src/opt.rs
+++ b/project-example/src/opt.rs
@@ -3,14 +3,15 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "project-example",
-    about = "A SpatialOS worker written in Rust."
+    about = "A SpatialOS worker written in Rust.",
+    rename_all="kebab-case"
 )]
 pub struct Opt {
-    #[structopt(name = "WORKER_TYPE", long, short = "w")]
-    pub worker_type: String,
-
-    #[structopt(name = "WORKER_ID", long, short = "i")]
+    #[structopt(long, short = "i")]
     pub worker_id: Option<String>,
+
+    #[structopt(long, short = "w")]
+    pub worker_type: String,
 
     #[structopt(subcommand)]
     pub command: Command,
@@ -30,15 +31,15 @@ pub enum Command {
 
     #[structopt(name = "locator")]
     Locator {
-        #[structopt(name = "PLAYER_IDENTITY_TOKEN", short = "p")]
+        #[structopt(short = "p")]
         player_identity_token: String,
-        #[structopt(name = "LOGIN_TOKEN", long, short = "t")]
+        #[structopt(long, short = "t")]
         login_token: String,
     },
 
     #[structopt(name = "dev-auth")]
     DevelopmentAuthentication {
-        #[structopt(name = "DEV_AUTH_TOKEN", long, short = "t")]
+        #[structopt(long, short = "t")]
         dev_auth_token: String,
     },
 }

--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 [dependencies]
 derivative = "1.0.2"
 spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
-futures = "0.1"
 inventory = "0.1"
 lazy_static = "1.3"
 

--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 derivative = "1.0.2"
+futures = "0.3.1"
 spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
 inventory = "0.1"
 lazy_static = "1.3"

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -218,19 +218,17 @@ impl WorkerConnection {
         let worker_id_cstr =
             CString::new(worker_id).expect("Received 0 byte in supplied Worker ID");
 
-        WorkerFuture::NotStarted(WorkerConnectionFuture::Receptionist(
-            hostname_cstr,
-            worker_id_cstr,
-            port,
-            params,
-        ))
+        let future =
+            WorkerConnectionFuture::Receptionist(hostname_cstr, worker_id_cstr, port, params);
+
+        WorkerFuture::new(future)
     }
 
     pub fn connect_locator(
         locator: Locator,
         params: ConnectionParameters,
     ) -> WorkerFuture<WorkerConnectionFuture> {
-        WorkerFuture::NotStarted(WorkerConnectionFuture::Locator(locator, params))
+        WorkerFuture::new(WorkerConnectionFuture::Locator(locator, params))
     }
 }
 

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -230,10 +230,7 @@ impl WorkerConnection {
         locator: Locator,
         params: ConnectionParameters,
     ) -> WorkerFuture<WorkerConnectionFuture> {
-        WorkerFuture::NotStarted(WorkerConnectionFuture::Locator(
-            locator,
-            params,
-        ))
+        WorkerFuture::NotStarted(WorkerConnectionFuture::Locator(locator, params))
     }
 }
 
@@ -641,9 +638,7 @@ impl WorkerSdkFuture for WorkerConnectionFuture {
             }
             WorkerConnectionFuture::Locator(locator, params) => {
                 let params = params.flatten();
-                unsafe {
-                    Worker_Locator_ConnectAsync(locator.locator, &params.as_raw())
-                }
+                unsafe { Worker_Locator_ConnectAsync(locator.locator, &params.as_raw()) }
             }
         }
     }

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -613,10 +613,6 @@ pub enum WorkerConnectionFuture {
     Locator(Locator, ConnectionParameters),
 }
 
-// SAFE: The Locator is owned by the WorkerConnectionFuture and cannot be copied or cloned so
-// the underlying pointer cannot be copied.
-unsafe impl Send for WorkerConnectionFuture {}
-
 impl WorkerSdkFuture for WorkerConnectionFuture {
     type RawPointer = Worker_ConnectionFuture;
     type Output = Result<WorkerConnection, ConnectionStatusError>;

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -12,13 +12,13 @@ use crate::worker::{
     {EntityId, InterestOverride, LogLevel, RequestId},
 };
 use spatialos_sdk_sys::worker::*;
+use std::sync::{Arc, Mutex};
 use std::{
     error::Error,
     ffi::{CStr, CString, NulError},
     fmt::{Display, Formatter},
     ptr,
 };
-use std::sync::{Arc, Mutex};
 
 pub type ConnectionStatus = Result<(), ConnectionStatusError>;
 
@@ -231,7 +231,10 @@ impl WorkerConnection {
         locator: Locator,
         params: ConnectionParameters,
     ) -> WorkerFuture<WorkerConnectionFuture> {
-        WorkerFuture::NotStarted(WorkerConnectionFuture::Locator(Arc::new(Mutex::new(locator)), params))
+        WorkerFuture::NotStarted(WorkerConnectionFuture::Locator(
+            Arc::new(Mutex::new(locator)),
+            params,
+        ))
     }
 }
 
@@ -638,7 +641,9 @@ impl WorkerSdkFuture for WorkerConnectionFuture {
             }
             WorkerConnectionFuture::Locator(locator, params) => {
                 let params = params.flatten();
-                unsafe { Worker_Locator_ConnectAsync(locator.lock().unwrap().locator, &params.as_raw()) }
+                unsafe {
+                    Worker_Locator_ConnectAsync(locator.lock().unwrap().locator, &params.as_raw())
+                }
             }
         }
     }

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -637,6 +637,8 @@ pub enum WorkerConnectionFuture {
     Locator(Locator, ConnectionParameters),
 }
 
+unsafe impl Send for WorkerConnectionFuture {}
+
 impl WorkerSdkFuture for WorkerConnectionFuture {
     type RawPointer = Worker_ConnectionFuture;
     type Output = Result<WorkerConnection, ConnectionStatusError>;

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -639,10 +639,10 @@ impl WorkerSdkFuture for WorkerConnectionFuture {
         }
     }
 
-    fn poll(
+    unsafe fn poll(
         ptr: *mut Worker_ConnectionFuture,
     ) -> Option<Result<WorkerConnection, ConnectionStatusError>> {
-        let connection_ptr = unsafe { Worker_ConnectionFuture_Get(ptr, &0) };
+        let connection_ptr = Worker_ConnectionFuture_Get(ptr, &0);
 
         if connection_ptr.is_null() {
             return None;
@@ -653,7 +653,7 @@ impl WorkerSdkFuture for WorkerConnectionFuture {
         Some(status.map(|()| connection))
     }
 
-    fn destroy(ptr: *mut Worker_ConnectionFuture) {
-        unsafe { Worker_ConnectionFuture_Destroy(ptr) };
+    unsafe fn destroy(ptr: *mut Worker_ConnectionFuture) {
+        Worker_ConnectionFuture_Destroy(ptr);
     }
 }

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -13,12 +13,10 @@ use crate::worker::{
 };
 use spatialos_sdk_sys::worker::*;
 use std::{
-    future::Future,
-    task::{Context, Poll},
+    error::Error,
+    fmt::{Display, Formatter},
     ffi::{CStr, CString, NulError},
-    pin::Pin,
     ptr,
-    sync::Arc
 };
 
 pub type ConnectionStatus = Result<(), ConnectionStatusError>;
@@ -36,6 +34,28 @@ pub enum ConnectionStatusError {
     CapacityExceeded(String),
     RateExceeded(String),
     ServerShutdown(String),
+}
+
+impl Display for ConnectionStatusError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectionStatusError::InternalError(detail) => f.write_fmt(format_args!("Internal error: {}", detail)),
+            ConnectionStatusError::InvalidArgument(detail) => f.write_fmt(format_args!("Invalid argument: {}", detail)),
+            ConnectionStatusError::NetworkError(detail) => f.write_fmt(format_args!("Network error: {}", detail)),
+            ConnectionStatusError::Timeout(detail) => f.write_fmt(format_args!("Timeout: {}", detail)),
+            ConnectionStatusError::Cancelled(detail) => f.write_fmt(format_args!("Cancelled: {}", detail)),
+            ConnectionStatusError::Rejected(detail) => f.write_fmt(format_args!("Rejected: {}", detail)),
+            ConnectionStatusError::PlayerIdentityTokenExpired(detail) => f.write_fmt(format_args!("Player identity token expired: {}", detail)),
+            ConnectionStatusError::LoginTokenExpired(detail) => f.write_fmt(format_args!("Login token expired: {}", detail)),
+            ConnectionStatusError::CapacityExceeded(detail) => f.write_fmt(format_args!("Capacity exceeded: {}", detail)),
+            ConnectionStatusError::RateExceeded(detail) => f.write_fmt(format_args!("Rate exceeded: {}", detail)),
+            ConnectionStatusError::ServerShutdown(detail) => f.write_fmt(format_args!("Server shutdown: {}", detail))
+        }
+    }
+}
+
+impl Error for ConnectionStatusError {
+
 }
 
 /// Connection trait to allow for mocking the connection.

--- a/spatialos-sdk/src/worker/internal/mod.rs
+++ b/spatialos-sdk/src/worker/internal/mod.rs
@@ -1,1 +1,57 @@
 pub(crate) mod utils;
+
+use std::task::{Context, Poll};
+use std::future::Future;
+use std::pin::Pin;
+
+pub enum WorkerFuture<T : WorkerSdkFuture + Unpin> {
+    NotStarted(T),
+    InProgress(*mut T::RawPointer),
+    Done
+}
+
+pub trait WorkerSdkFuture {
+    type RawPointer;
+    type Output;
+
+    fn start(&self) -> *mut Self::RawPointer;
+    fn poll(ptr: *mut Self::RawPointer) -> Option<Self::Output>;
+    fn destroy(ptr: *mut Self::RawPointer);
+}
+
+impl<T: WorkerSdkFuture + Unpin> Future for WorkerFuture<T> {
+    type Output = T::Output;
+
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut result = Poll::Pending;
+        let mut next = None;
+
+        match self.as_mut().get_mut() {
+            WorkerFuture::NotStarted(future) => {
+                let ptr= future.start();
+                next = Some(WorkerFuture::InProgress(ptr));
+            },
+            WorkerFuture::InProgress(ptr) => {
+                if let Some(value) = T::poll(*ptr) {
+                    result = Poll::Ready(value);
+                    next = Some(WorkerFuture::Done);
+                }
+            },
+            WorkerFuture::Done => panic!("Future already completed".to_string())
+        }
+
+        if let Some(ref mut next) = next {
+            std::mem::swap(self.as_mut().get_mut(), next);
+        }
+
+        result
+    }
+}
+
+impl<T: WorkerSdkFuture + Unpin> Drop for WorkerFuture<T> {
+    fn drop(&mut self) {
+        if let WorkerFuture::InProgress(ptr) = self {
+            T::destroy(*ptr);
+        }
+    }
+}

--- a/spatialos-sdk/src/worker/locator.rs
+++ b/spatialos-sdk/src/worker/locator.rs
@@ -249,22 +249,20 @@ impl WorkerSdkFuture for PlayerIdentityTokenFuture {
         }
     }
 
-    fn poll(ptr: *mut Self::RawPointer) -> Option<Self::Output> {
+    unsafe fn poll(ptr: *mut Self::RawPointer) -> Option<Self::Output> {
         let mut data: Option<Result<PlayerIdentityTokenResponse, String>> = None;
-        unsafe {
-            Worker_Alpha_PlayerIdentityTokenResponseFuture_Get(
-                ptr,
-                &0,
-                &mut data as *mut _ as *mut ::std::os::raw::c_void,
-                Some(PlayerIdentityTokenFuture::callback_handler),
-            );
-        }
+        Worker_Alpha_PlayerIdentityTokenResponseFuture_Get(
+            ptr,
+            &0,
+            &mut data as *mut _ as *mut ::std::os::raw::c_void,
+            Some(PlayerIdentityTokenFuture::callback_handler),
+        );
 
         data
     }
 
-    fn destroy(ptr: *mut Self::RawPointer) {
-        unsafe { Worker_Alpha_PlayerIdentityTokenResponseFuture_Destroy(ptr) }
+    unsafe fn destroy(ptr: *mut Self::RawPointer) {
+        Worker_Alpha_PlayerIdentityTokenResponseFuture_Destroy(ptr)
     }
 }
 
@@ -410,21 +408,19 @@ impl WorkerSdkFuture for LoginTokensFuture {
         }
     }
 
-    fn poll(ptr: *mut Self::RawPointer) -> Option<Self::Output> {
+    unsafe fn poll(ptr: *mut Self::RawPointer) -> Option<Self::Output> {
         let mut data: Option<Result<LoginTokensResponse, String>> = None;
-        unsafe {
-            Worker_Alpha_LoginTokensResponseFuture_Get(
-                ptr,
-                &0,
-                &mut data as *mut _ as *mut ::std::os::raw::c_void,
-                Some(LoginTokensFuture::callback_handler),
-            );
-        }
+        Worker_Alpha_LoginTokensResponseFuture_Get(
+            ptr,
+            &0,
+            &mut data as *mut _ as *mut ::std::os::raw::c_void,
+            Some(LoginTokensFuture::callback_handler),
+        );
 
         data
     }
 
-    fn destroy(ptr: *mut Self::RawPointer) {
-        unsafe { Worker_Alpha_LoginTokensResponseFuture_Destroy(ptr) }
+    unsafe fn destroy(ptr: *mut Self::RawPointer) {
+        Worker_Alpha_LoginTokensResponseFuture_Destroy(ptr)
     }
 }

--- a/spatialos-sdk/src/worker/locator.rs
+++ b/spatialos-sdk/src/worker/locator.rs
@@ -30,7 +30,7 @@ impl Locator {
         request: PlayerIdentityTokenRequest,
     ) -> WorkerFuture<PlayerIdentityTokenFuture> {
         let cstr = CString::new(hostname).unwrap();
-        WorkerFuture::NotStarted(PlayerIdentityTokenFuture::new(cstr, port, request))
+        WorkerFuture::new(PlayerIdentityTokenFuture::new(cstr, port, request))
     }
 
     pub fn create_development_login_tokens(
@@ -39,7 +39,7 @@ impl Locator {
         request: LoginTokensRequest,
     ) -> WorkerFuture<LoginTokensFuture> {
         let cstr = CString::new(hostname).unwrap();
-        WorkerFuture::NotStarted(LoginTokensFuture::new(cstr, port, request))
+        WorkerFuture::new(LoginTokensFuture::new(cstr, port, request))
     }
 }
 

--- a/spatialos-sdk/src/worker/locator.rs
+++ b/spatialos-sdk/src/worker/locator.rs
@@ -2,9 +2,11 @@ use std::ffi::CString;
 
 use spatialos_sdk_sys::worker::*;
 
-use crate::worker::internal::utils::cstr_to_string;
-use crate::worker::parameters::ProtocolLoggingParameters;
-use crate::worker::internal::{WorkerSdkFuture, WorkerFuture};
+use crate::worker::{
+    parameters::ProtocolLoggingParameters,
+    utils::cstr_to_string,
+    worker_future::{WorkerFuture, WorkerSdkFuture},
+};
 
 pub struct Locator {
     pub(crate) locator: *mut Worker_Locator,
@@ -197,7 +199,7 @@ impl PlayerIdentityTokenResponse {
 pub struct PlayerIdentityTokenFuture {
     request: PlayerIdentityTokenRequest,
     hostname: CString,
-    port: u16
+    port: u16,
 }
 
 impl PlayerIdentityTokenFuture {
@@ -205,7 +207,7 @@ impl PlayerIdentityTokenFuture {
         PlayerIdentityTokenFuture {
             request,
             hostname,
-            port
+            port,
         }
     }
 
@@ -359,7 +361,7 @@ impl LoginTokenDetails {
 pub struct LoginTokensFuture {
     request: LoginTokensRequest,
     hostname: CString,
-    port: u16
+    port: u16,
 }
 
 impl LoginTokensFuture {
@@ -367,7 +369,7 @@ impl LoginTokensFuture {
         LoginTokensFuture {
             request,
             hostname,
-            port
+            port,
         }
     }
 

--- a/spatialos-sdk/src/worker/locator.rs
+++ b/spatialos-sdk/src/worker/locator.rs
@@ -1,7 +1,4 @@
 use std::ffi::CString;
-use std::sync::Arc;
-use std::future::Future;
-use std::task::{Context, Poll};
 
 use spatialos_sdk_sys::worker::*;
 

--- a/spatialos-sdk/src/worker/locator.rs
+++ b/spatialos-sdk/src/worker/locator.rs
@@ -8,7 +8,6 @@ use crate::worker::{
     utils::cstr_to_string,
     worker_future::{WorkerFuture, WorkerSdkFuture},
 };
-use std::sync::{Mutex, Arc};
 
 pub struct Locator {
     pub(crate) locator: *mut Worker_Locator,
@@ -220,8 +219,7 @@ impl PlayerIdentityTokenFuture {
         assert!(!response.is_null());
         unsafe {
             let response = *response;
-            let data =
-                &mut *(user_data as *mut Result<PlayerIdentityTokenResponse, String>);
+            let data = &mut *(user_data as *mut Result<PlayerIdentityTokenResponse, String>);
             if Worker_ConnectionStatusCode::from(response.status.code)
                 != Worker_ConnectionStatusCode_WORKER_CONNECTION_STATUS_CODE_SUCCESS
             {
@@ -252,7 +250,8 @@ impl WorkerSdkFuture for PlayerIdentityTokenFuture {
     }
 
     unsafe fn get(ptr: *mut Self::RawPointer) -> Self::Output {
-        let mut data: Result<PlayerIdentityTokenResponse, String> = Err("Callback never called.".into());
+        let mut data: Result<PlayerIdentityTokenResponse, String> =
+            Err("Callback never called.".into());
         Worker_Alpha_PlayerIdentityTokenResponseFuture_Get(
             ptr,
             ptr::null(),

--- a/spatialos-sdk/src/worker/locator.rs
+++ b/spatialos-sdk/src/worker/locator.rs
@@ -1,4 +1,5 @@
 use std::ffi::CString;
+use std::ptr;
 
 use spatialos_sdk_sys::worker::*;
 
@@ -7,6 +8,7 @@ use crate::worker::{
     utils::cstr_to_string,
     worker_future::{WorkerFuture, WorkerSdkFuture},
 };
+use std::sync::{Mutex, Arc};
 
 pub struct Locator {
     pub(crate) locator: *mut Worker_Locator,
@@ -219,17 +221,17 @@ impl PlayerIdentityTokenFuture {
         unsafe {
             let response = *response;
             let data =
-                &mut *(user_data as *mut Option<Result<PlayerIdentityTokenResponse, String>>);
+                &mut *(user_data as *mut Result<PlayerIdentityTokenResponse, String>);
             if Worker_ConnectionStatusCode::from(response.status.code)
                 != Worker_ConnectionStatusCode_WORKER_CONNECTION_STATUS_CODE_SUCCESS
             {
                 let err = cstr_to_string(response.status.detail);
-                *data = Some(Err(err));
+                *data = Err(err);
                 return;
             }
 
             let response = PlayerIdentityTokenResponse::from_worker_sdk(&response);
-            *data = Some(Ok(response));
+            *data = Ok(response);
         }
     }
 }
@@ -249,11 +251,11 @@ impl WorkerSdkFuture for PlayerIdentityTokenFuture {
         }
     }
 
-    unsafe fn poll(ptr: *mut Self::RawPointer) -> Option<Self::Output> {
-        let mut data: Option<Result<PlayerIdentityTokenResponse, String>> = None;
+    unsafe fn get(ptr: *mut Self::RawPointer) -> Self::Output {
+        let mut data: Result<PlayerIdentityTokenResponse, String> = Err("Callback never called.".into());
         Worker_Alpha_PlayerIdentityTokenResponseFuture_Get(
             ptr,
-            &0,
+            ptr::null(),
             &mut data as *mut _ as *mut ::std::os::raw::c_void,
             Some(PlayerIdentityTokenFuture::callback_handler),
         );
@@ -378,17 +380,17 @@ impl LoginTokensFuture {
         assert!(!response.is_null());
         unsafe {
             let response = *response;
-            let data = &mut *(user_data as *mut Option<Result<LoginTokensResponse, String>>);
+            let data = &mut *(user_data as *mut Result<LoginTokensResponse, String>);
             if Worker_ConnectionStatusCode::from(response.status.code)
                 != Worker_ConnectionStatusCode_WORKER_CONNECTION_STATUS_CODE_SUCCESS
             {
                 let err = cstr_to_string(response.status.detail);
-                *data = Some(Err(err));
+                *data = Err(err);
                 return;
             }
 
             let response = LoginTokensResponse::from_worker_sdk(&response);
-            *data = Some(Ok(response));
+            *data = Ok(response);
         }
     }
 }
@@ -408,11 +410,11 @@ impl WorkerSdkFuture for LoginTokensFuture {
         }
     }
 
-    unsafe fn poll(ptr: *mut Self::RawPointer) -> Option<Self::Output> {
-        let mut data: Option<Result<LoginTokensResponse, String>> = None;
+    unsafe fn get(ptr: *mut Self::RawPointer) -> Self::Output {
+        let mut data: Result<LoginTokensResponse, String> = Err("Callback never called.".into());
         Worker_Alpha_LoginTokensResponseFuture_Get(
             ptr,
-            &0,
+            ptr::null(),
             &mut data as *mut _ as *mut ::std::os::raw::c_void,
             Some(LoginTokensFuture::callback_handler),
         );

--- a/spatialos-sdk/src/worker/metrics.rs
+++ b/spatialos-sdk/src/worker/metrics.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::ffi::CString;
 use std::slice;
 
-use crate::worker::internal::utils::cstr_to_string;
+use crate::worker::utils::cstr_to_string;
 use spatialos_sdk_sys::worker::{
     Worker_GaugeMetric, Worker_HistogramMetric, Worker_HistogramMetricBucket, Worker_Metrics,
 };

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -1,5 +1,3 @@
-pub mod internal;
-
 pub mod commands;
 pub mod component;
 pub mod connection;
@@ -12,7 +10,9 @@ pub mod parameters;
 pub mod query;
 pub mod schema;
 pub mod snapshot;
+pub(crate) mod utils;
 pub mod vtable;
+pub mod worker_future;
 
 use component::ComponentId;
 use derivative::Derivative;
@@ -187,6 +187,5 @@ pub enum ConnectionStatusCode {
 pub mod constants {
     pub const LOCATOR_HOSTNAME: &str = "locator.improbable.io";
     pub const LOCATOR_PORT: u16 = 444;
-
     pub const RECEPTIONIST_PORT: u16 = 7777;
 }

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -6,7 +6,7 @@ use crate::worker::{
     entity::Entity,
     metrics::Metrics,
     schema::{self, ObjectField},
-    utils::{cstr_to_string, cstr_array_to_vec_string},
+    utils::{cstr_array_to_vec_string, cstr_to_string},
     {Authority, EntityId, LogLevel, RequestId},
 };
 use spatialos_sdk_sys::worker::*;

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -4,9 +4,9 @@ use crate::worker::{
     commands::*,
     component::{self, *},
     entity::Entity,
-    internal::utils::*,
     metrics::Metrics,
     schema::{self, ObjectField},
+    utils::{cstr_to_string, cstr_array_to_vec_string},
     {Authority, EntityId, LogLevel, RequestId},
 };
 use spatialos_sdk_sys::worker::*;
@@ -28,7 +28,7 @@ impl OpList {
     ///
     /// ```no_run
     /// # use spatialos_sdk::worker::connection::*;
-    /// # let connection: WorkerConnection = unimplemented!();
+    /// # let mut connection: WorkerConnection = unimplemented!();
     /// for op in connection.get_op_list(0).iter() {
     ///     // Process `op`.
     /// }

--- a/spatialos-sdk/src/worker/snapshot.rs
+++ b/spatialos-sdk/src/worker/snapshot.rs
@@ -1,7 +1,4 @@
-use crate::{
-    worker::component::DATABASE, worker::entity::Entity, worker::internal::utils::cstr_to_string,
-    worker::EntityId,
-};
+use crate::worker::{component::DATABASE, entity::Entity, utils::cstr_to_string, EntityId};
 use spatialos_sdk_sys::worker::*;
 use std::{ffi::CString, path::Path};
 

--- a/spatialos-sdk/src/worker/utils.rs
+++ b/spatialos-sdk/src/worker/utils.rs
@@ -16,7 +16,6 @@ pub fn cstr_array_to_vec_string(
 ) -> Vec<String> {
     unsafe {
         (0..count as isize)
-            .into_iter()
             .map(|i| {
                 let ptr = char_ptr.offset(i) as *mut *const std::os::raw::c_char;
                 assert!(!ptr.is_null());

--- a/spatialos-sdk/src/worker/utils.rs
+++ b/spatialos-sdk/src/worker/utils.rs
@@ -14,13 +14,14 @@ pub fn cstr_array_to_vec_string(
     char_ptr: *mut *const std::os::raw::c_char,
     count: u32,
 ) -> Vec<String> {
-    let mut strings = Vec::new();
     unsafe {
-        for i in 0..count as isize {
-            let ptr = char_ptr.offset(i) as *mut *const std::os::raw::c_char;
-            assert!(!ptr.is_null());
-            strings.push(cstr_to_string(*ptr));
-        }
+        (0..count as isize)
+            .into_iter()
+            .map(|i| {
+                let ptr = char_ptr.offset(i) as *mut *const std::os::raw::c_char;
+                assert!(!ptr.is_null());
+                cstr_to_string(*ptr)
+            })
+            .collect()
     }
-    strings
 }

--- a/spatialos-sdk/src/worker/worker_future.rs
+++ b/spatialos-sdk/src/worker/worker_future.rs
@@ -39,7 +39,7 @@ impl<T: WorkerSdkFuture> Drop for WorkerFuture<T> {
     }
 }
 
-pub trait WorkerSdkFuture: Send + Unpin {
+pub trait WorkerSdkFuture: Send + Unpin + 'static {
     type RawPointer;
     type Output: Send;
 
@@ -48,7 +48,7 @@ pub trait WorkerSdkFuture: Send + Unpin {
     unsafe fn destroy(ptr: *mut Self::RawPointer);
 }
 
-impl<T: WorkerSdkFuture + 'static> Future for WorkerFuture<T> {
+impl<T: WorkerSdkFuture> Future for WorkerFuture<T> {
     type Output = T::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/spatialos-sdk/src/worker/worker_future.rs
+++ b/spatialos-sdk/src/worker/worker_future.rs
@@ -43,7 +43,7 @@ struct SendPtr<T> {
 
 unsafe impl<T> Send for SendPtr<T> {}
 
-pub trait WorkerSdkFuture: Unpin + Send {
+pub trait WorkerSdkFuture: Unpin {
     type RawPointer;
     type Output: Send;
 

--- a/spatialos-sdk/src/worker/worker_future.rs
+++ b/spatialos-sdk/src/worker/worker_future.rs
@@ -38,11 +38,12 @@ impl<T: WorkerSdkFuture> Clone for WorkerFutureHandle<T> {
 // Given the following rules, we can guarantee that its thread-safe:
 //
 //  1. Poll cannot be called after Destroy.
-//
-// We ensure this cannot be true as we store a reference to the handle of the thread where Poll
-// could be running. If this reference is present in the handle during drop(), we join that thread.
-// This guarantees us that poll has already begun (and then finished) by the time Destroy is called.
-// Since we only ever call Poll once, we cannot possibly call Poll after Destroy.
+//      We ensure this cannot be true as we store a reference to the handle of the thread where Poll
+//      could be running. If this reference is present in the handle during drop(), we join that thread.
+//      This guarantees us that poll has already begun (and then finished) by the time Destroy is called.
+//      Since we only ever call Poll once, we cannot possibly call Poll after Destroy.
+//  2. Destroy is called at most once.
+//      We call Destroy in the drop() of the WorkerFuture<T> only. Something cannot be dropped more than once.
 //
 // This has the side effect the the Drop impl can block, but this was the already the case anyway with the
 // Worker SDK future Destroy methods (which I believe wait for the future to complete).

--- a/spatialos-sdk/src/worker/worker_future.rs
+++ b/spatialos-sdk/src/worker/worker_future.rs
@@ -1,26 +1,26 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::thread;
 
 pub enum WorkerFuture<T: WorkerSdkFuture + Unpin + Send> {
     NotStarted(T),
-    InProgress(Arc<Mutex<WorkerFutureHandle<T>>>)
+    InProgress(Arc<Mutex<WorkerFutureHandle<T>>>),
 }
 
 pub struct WorkerFutureHandle<T: WorkerSdkFuture + Unpin + Send> {
     pub(crate) ptr: *mut T::RawPointer,
-    pub(crate) shared_result: Option<T::Output>
+    pub(crate) shared_result: Option<T::Output>,
 }
 
 unsafe impl<T: WorkerSdkFuture + Unpin + Send> Send for WorkerFutureHandle<T> {}
 
 impl<T: WorkerSdkFuture + Unpin + Send> WorkerFutureHandle<T> {
-    pub (crate) fn new(ptr: *mut T::RawPointer) -> Arc<Mutex<Self>> {
+    pub(crate) fn new(ptr: *mut T::RawPointer) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(WorkerFutureHandle {
             ptr,
-            shared_result: None
+            shared_result: None,
         }))
     }
 }
@@ -38,7 +38,7 @@ impl<T: WorkerSdkFuture + Unpin + Send + 'static> Future for WorkerFuture<T> {
     type Output = T::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut next = None;
+        let mut next_state;
 
         match self.as_mut().get_mut() {
             WorkerFuture::NotStarted(future) => {
@@ -54,18 +54,18 @@ impl<T: WorkerSdkFuture + Unpin + Send + 'static> Future for WorkerFuture<T> {
                     thread_waker.wake();
                 });
 
-                next = Some(WorkerFuture::InProgress(handle));
+                next_state = Some(WorkerFuture::InProgress(handle));
             }
-            WorkerFuture::InProgress(context) => unsafe {
+            WorkerFuture::InProgress(context) => {
                 return Poll::Ready(context.lock().unwrap().shared_result.take().unwrap());
-            }
+            },
         }
 
-        if let Some(ref mut next) = next {
+        if let Some(ref mut next) = next_state {
             std::mem::swap(self.as_mut().get_mut(), next);
         }
 
-        return Poll::Pending;
+        Poll::Pending
     }
 }
 

--- a/spatialos-sdk/src/worker/worker_future.rs
+++ b/spatialos-sdk/src/worker/worker_future.rs
@@ -8,13 +8,13 @@ use std::{
 };
 
 pub struct WorkerFuture<T: WorkerSdkFuture> {
-    inner: WorkerFutureState<T>,
+    inner: Option<WorkerFutureState<T>>,
 }
 
 impl<T: WorkerSdkFuture> WorkerFuture<T> {
     pub fn new(future: T) -> Self {
         WorkerFuture {
-            inner: WorkerFutureState::NotStarted(future),
+            inner: Some(WorkerFutureState::NotStarted(future)),
         }
     }
 }
@@ -31,8 +31,10 @@ struct InProgressHandle<T: WorkerSdkFuture> {
 
 impl<T: WorkerSdkFuture> Drop for WorkerFuture<T> {
     fn drop(&mut self) {
-        if let WorkerFutureState::InProgress(handle) = &mut self.inner {
-            handle.thread.take().unwrap().join().unwrap();
+        if let Some(future_state) = &mut self.inner {
+            if let WorkerFutureState::InProgress(handle) = future_state {
+                handle.thread.take().unwrap().join().unwrap();
+            }
         }
     }
 }
@@ -50,49 +52,38 @@ impl<T: WorkerSdkFuture + 'static> Future for WorkerFuture<T> {
     type Output = T::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let future_state = &mut self.as_mut().get_mut().inner;
+        let inner = &mut self.as_mut().get_mut().inner;
+        // This panics if the future is polled after completion. This is acceptable according to
+        // the Future trait contract - https://doc.rust-lang.org/std/future/trait.Future.html#panics
+        let mut future_state = inner.take().unwrap();
 
         match future_state {
-            // We don't want to borrow the WorkerSdkFuture object. We want to take it so we can
-            // send it to the thread which will block on the Worker SDK future.
-            // To do this, we construct the next state and then mem swap them.
-            // We do have to add the thread handle _after_ we start the thread though,
-            // so it gets a little awkward.
-            // Rust's enum destructing lets us down a little bit here.
-            WorkerFutureState::NotStarted(_) => {
+            WorkerFutureState::NotStarted(ftr) => {
                 let (tx, rx) = futures::channel::oneshot::channel();
                 let task = cx.waker().clone();
 
-                let mut state = WorkerFutureState::InProgress(InProgressHandle::<T> {
-                    result_rx: rx,
-                    thread: None,
+                let thread = thread::spawn(move || unsafe {
+                    let ptr = ftr.start();
+                    let value = T::get(ptr);
+                    tx.send(value).unwrap_or(());
+                    task.wake();
+                    T::destroy(ptr)
                 });
 
-                std::mem::swap(future_state, &mut state);
+                let handle = InProgressHandle::<T> {
+                    result_rx: rx,
+                    thread: Some(thread),
+                };
 
-                // This is always true.
-                if let WorkerFutureState::NotStarted(ftr) = state {
-                    let thread = thread::spawn(move || unsafe {
-                        let ptr = ftr.start();
-                        let value = T::get(ptr);
-                        tx.send(value).unwrap_or(());
-                        task.wake();
-                        T::destroy(ptr)
-                    });
-
-                    // As is this one.
-                    if let WorkerFutureState::InProgress(handle) = future_state {
-                        handle.thread = Some(thread);
-                    }
-                }
-
+                *inner = Some(WorkerFutureState::InProgress(handle));
                 Poll::Pending
             }
-            WorkerFutureState::InProgress(handle) => {
+            WorkerFutureState::InProgress(ref mut handle) => {
                 if let Some(val) = handle.result_rx.try_recv().unwrap_or(None) {
                     return Poll::Ready(val);
                 }
 
+                *inner = Some(future_state);
                 Poll::Pending
             }
         }

--- a/spatialos-sdk/src/worker/worker_future.rs
+++ b/spatialos-sdk/src/worker/worker_future.rs
@@ -76,7 +76,6 @@ impl<T: WorkerSdkFuture> Future for WorkerFuture<T> {
                 };
 
                 *inner = Some(WorkerFutureState::InProgress(handle));
-                Poll::Pending
             }
             WorkerFutureState::InProgress(ref mut handle) => {
                 if let Some(val) = handle.result_rx.try_recv().unwrap_or(None) {
@@ -84,8 +83,9 @@ impl<T: WorkerSdkFuture> Future for WorkerFuture<T> {
                 }
 
                 *inner = Some(future_state);
-                Poll::Pending
             }
         }
+
+        Poll::Pending
     }
 }


### PR DESCRIPTION
This PR is a grab bag of things: 

- Use the standard library `Future` trait for the Worker SDK futures! Move to using async-await with the worker SDK futures. 
- Remove the `internal` module and move `utils` up one module.
- Refactoring the connection error handling structs
- All the connection methods consume the `ConnectionParameters` struct rather than borrow it.

If people wish, I can attempt to split these into multiple PRs