### PR TITLE
Fix CLI for example project

### DIFF
--- a/cargo-spatial/src/local.rs
+++ b/cargo-spatial/src/local.rs
@@ -18,7 +18,7 @@ pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Box<dyn std::
     // Run codegen and such.
     crate::codegen::run_codegen(config)?;
 
-    // Use `cargo install` to build workers and copy the exectuables to the build
+    // Use `cargo install` to build workers and copy the executables to the build
     // directory.
     //
     // TODO: Manually copy the built executables instead of using `cargo install`.
@@ -38,6 +38,7 @@ pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Box<dyn std::
                 .arg(&build_dir)
                 .arg("--force")
                 .arg("--path")
+                .arg("--locked")
                 .arg(worker_path);
 
             if config.local_build_profile == BuildProfile::Debug {

--- a/project-example/src/opt.rs
+++ b/project-example/src/opt.rs
@@ -6,13 +6,13 @@ use structopt::StructOpt;
     about = "A SpatialOS worker written in Rust."
 )]
 pub struct Opt {
-    #[structopt(name = "WORKER_TYPE", long, short = "w")]
+    #[structopt(long, short = "w")]
     pub worker_type: String,
 
-    #[structopt(name = "WORKER_ID", long, short = "i")]
+    #[structopt(long, short = "i")]
     pub worker_id: Option<String>,
 
-    #[structopt(name = "POLLING_CONNECTION", long = "polling-connection", short = "p")]
+    #[structopt(long = "polling-connection", short = "p")]
     pub connect_with_poll: bool,
 
     #[structopt(subcommand)]
@@ -33,15 +33,15 @@ pub enum Command {
 
     #[structopt(name = "locator")]
     Locator {
-        #[structopt(name = "PLAYER_IDENTITY_TOKEN", short = "p")]
+        #[structopt(short = "p")]
         player_identity_token: String,
-        #[structopt(name = "LOGIN_TOKEN", long, short = "t")]
+        #[structopt(long, short = "t")]
         login_token: String,
     },
 
     #[structopt(name = "dev-auth")]
     DevelopmentAuthentication {
-        #[structopt(name = "DEV_AUTH_TOKEN", long, short = "t")]
+        #[structopt(long, short = "t")]
         dev_auth_token: String,
     },
 }


### PR DESCRIPTION
I ran into an issue where the executable generated by `cargo spatial local launch` was expecting different command line parameters than what we intended, specifically it was expecting `--WORKER_ID` instead of `--worker-id`. When running the executable with `cargo run` directly, it would have the expected CLI.

After some digging, it looks like the difference was because `cargo install` (which is used by `cargo spatial local launch` to build the worker) ignores the project's lock file by default, causing the version built for the local deployment to be different than the version built normally. To address these issues I've made two changes:

* Remove explicit `structopt(name)` attributes. This was causing structopt's default behavior of renaming all fields to be kebab-case to fail. This is due to a change introduced in [structopt v0.3.4](https://github.com/TeXitoi/structopt/blob/master/CHANGELOG.md#v034-2019-11-08).
* Specify `--locked` flag when building local project. This will ensure `cargo spatial local launch` will use the same dependency versions as `cargo run`, cutting down on possible confusion.