### PR TITLE
Better error handling in codegen

### DIFF
--- a/cargo-spatial/src/codegen.rs
+++ b/cargo-spatial/src/codegen.rs
@@ -2,25 +2,79 @@ use crate::config::Config;
 use crate::format_arg;
 use log::*;
 use spatialos_sdk_code_generator::{generator, schema_bundle};
-use std::fs::{self, File};
-use std::io::prelude::*;
-use std::path::*;
-use std::process::Command;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+    fs::{self, File},
+    io::prelude::*,
+    path::*,
+    process::Command
+};
+
+#[derive(Debug)]
+pub enum CodegenErrorKind {
+    BadConfig,
+    SchemaCompiler,
+    InvalidBundle,
+    IO,
+}
+
+impl Display for CodegenErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            CodegenErrorKind::BadConfig => f.write_str("Bad Config"),
+            CodegenErrorKind::SchemaCompiler => f.write_str("Schema Compiler Error"),
+            CodegenErrorKind::InvalidBundle => f.write_str("Invalid Schema Bundle"),
+            CodegenErrorKind::IO => f.write_str("IO Error"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CodegenError {
+    kind: CodegenErrorKind,
+    msg: String,
+    inner: Option<Box<dyn Error>>,
+}
+
+impl Display for CodegenError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let mut msg = format!("{}: {}", self.kind, self.msg);
+
+        if let Some(ref inner) = self.inner {
+            msg = format!("{}\nInner error: {}", msg, inner);
+        }
+
+        f.write_str(&msg)
+    }
+}
+
+impl Error for CodegenError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.inner.as_ref().map(|e| e.as_ref())
+    }
+}
 
 /// Performs code generation for the project described by `config`.
 ///
 /// Assumes that the current working directory is the root directory of the project,
 /// i.e. the directory that has the `Spatial.toml` file.
-pub fn run_codegen(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
-    assert!(
-        crate::current_dir_is_root(),
-        "Current directory should be the project root"
-    );
+pub fn run_codegen(config: &Config) -> Result<(), CodegenError> {
+    if !crate::current_dir_is_root() {
+        return Err(CodegenError {
+            msg: "Current directory should be the project root.".into(),
+            kind: CodegenErrorKind::BadConfig,
+            inner: None,
+        });
+    }
 
     // Ensure that the path to the Spatial SDK has been specified.
     let spatial_lib_dir = config.spatial_lib_dir()
         .map(PathBuf::from)
-        .ok_or("spatial_lib_dir value must be set in the config, or the SPATIAL_LIB_DIR environment variable must be set")?;
+        .ok_or(CodegenError {
+            msg: "spatial_lib_dir value must be set in the config, or the SPATIAL_LIB_DIR environment variable must be set.".into(),
+            kind: CodegenErrorKind::BadConfig,
+            inner: None})?;
 
     // Determine the paths the the schema compiler and protoc relative the the lib
     // dir path.
@@ -33,8 +87,14 @@ pub fn run_codegen(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
     let schema_descriptor_path = output_dir.join("schema.descriptor");
 
     // Create the output directory if it doesn't already exist.
-    fs::create_dir_all(&output_dir)
-        .map_err(|_| format!("Failed to create {}", output_dir.display()))?;
+    fs::create_dir_all(&output_dir).map_err(|e| {
+        let msg = format!("Failed to create {}", output_dir.display());
+        CodegenError {
+            msg,
+            kind: CodegenErrorKind::IO,
+            inner: Some(Box::new(e)),
+        }
+    })?;
     trace!("Created schema output dir: {}", output_dir.display());
 
     // Prepare initial flags for the schema compiler.
@@ -61,31 +121,57 @@ pub fn run_codegen(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     trace!("{:#?}", command);
-    let status = command
-        .status()
-        .map_err(|_| "Failed to compile schema files")?;
+    let status = command.status().map_err(|e| CodegenError {
+        msg: "Failed to compile schema files".into(),
+        kind: CodegenErrorKind::SchemaCompiler,
+        inner: Some(Box::new(e)),
+    })?;
 
     if !status.success() {
-        return Err("Failed to run schema compilation".into());
+        return Err(CodegenError {
+            msg: "Failed to run schema compilation".into(),
+            kind: CodegenErrorKind::SchemaCompiler,
+            inner: None,
+        });
     }
 
     // Load bundle.json, which describes the schema definitions for all components.
-    let mut input_file = File::open(&bundle_json_path).map_err(|_| "Failed to open bundle.json")?;
+    let mut input_file = File::open(&bundle_json_path).map_err(|e| CodegenError {
+        msg: "Failed to open bundle.json".into(),
+        kind: CodegenErrorKind::SchemaCompiler,
+        inner: Some(Box::new(e)),
+    })?;
+
     let mut contents = String::new();
     input_file
         .read_to_string(&mut contents)
-        .map_err(|_| "Failed to read contents of bundle.json")?;
+        .map_err(|e| CodegenError {
+            msg: "Failed to read contents of bundle.json".into(),
+            kind: CodegenErrorKind::IO,
+            inner: Some(Box::new(e)),
+        })?;
 
     // Run code generation.
-    let bundle = schema_bundle::load_bundle(&contents)
-        .map_err(|_| "Failed to parse contents of bundle.json")?;
+    let bundle = schema_bundle::load_bundle(&contents).map_err(|e| CodegenError {
+        msg: "Failed to parse contents of bundle.json".into(),
+        kind: CodegenErrorKind::InvalidBundle,
+        inner: Some(Box::new(e)),
+    })?;
     let generated_file = generator::generate_code(bundle);
 
     // Write the generated code to the output file.
     File::create(&config.codegen_out)
-        .map_err(|_| "Unable to create codegen output file")?
+        .map_err(|e| CodegenError {
+            msg: "Unable to create codegen output file".into(),
+            kind: CodegenErrorKind::IO,
+            inner: Some(Box::new(e)),
+        })?
         .write_all(generated_file.as_bytes())
-        .map_err(|_| "Failed to write generated code to file")?;
+        .map_err(|e| CodegenError {
+            msg: "Failed to write generated code to file".into(),
+            kind: CodegenErrorKind::IO,
+            inner: Some(Box::new(e)),
+        })?;
 
     Ok(())
 }

--- a/cargo-spatial/src/codegen.rs
+++ b/cargo-spatial/src/codegen.rs
@@ -8,7 +8,7 @@ use std::{
     fs::{self, File},
     io::prelude::*,
     path::*,
-    process::Command
+    process::Command,
 };
 
 #[derive(Debug)]

--- a/spatialos-sdk-code-generator/src/schema_bundle.rs
+++ b/spatialos-sdk-code-generator/src/schema_bundle.rs
@@ -77,11 +77,11 @@ pub enum Value_Value {
     #[serde(rename = "uint32Value")]
     Uint32Value(u32),
     #[serde(rename = "uint64Value")]
-    Uint64Value(u64),
+    Uint64Value(String),
     #[serde(rename = "int32Value")]
     Int32Value(i32),
     #[serde(rename = "int64Value")]
-    Int64Value(i64),
+    Int64Value(String),
     #[serde(rename = "floatValue")]
     FloatValue(f32),
     #[serde(rename = "doubleValue")]
@@ -91,7 +91,7 @@ pub enum Value_Value {
     #[serde(rename = "bytesValue")]
     BytesValue(String),
     #[serde(rename = "entityIdValue")]
-    EntityIdValue(i64),
+    EntityIdValue(String),
     #[serde(rename = "enumValue")]
     EnumValue {
         #[serde(rename = "enum")]


### PR DESCRIPTION
While looking at add automated testing against the exhaustive test schema, I ran into issues where schema bundles that failed to be parsed would not give the underlying error. 

To resolve this, I've added more robust error handling in the codegen command so we no longer swallow the underlying errors. No fancy error handling crates, just using the std library (for now anyway, given how much they seem to churn).

I'll probably go over the rest of `cargo-spatial` and clean up error handling if we are happy with this pattern. An example error looks like: 

```
jamie /c/Workspace/spatialos-sdk-rs/test-suite (feature/exhaustive-test-schema) 
λ cargo spatial codegen
Error: CodegenError { kind: InvalidBundle, msg: "Failed to parse contents of bundle.json", inner: Some(Error("invalid type: string \"10\", expected i64", line: 1573, column: 11)) }
```

I also fixed a few bugs with the schema annotation `Value_Value` fields. (The `int64`, `uint64` and `EntityId` fields are encoded as strings in JSON rather than numeric types.

---

As an aside, the exhaustive schema testing will have to wait until we implement the `Entity` schema type. Which will probably wait until the serialization changes are done.