### PR TITLE
`cargo-spatial` error handling consolidation

### DIFF
--- a/cargo-spatial/src/codegen.rs
+++ b/cargo-spatial/src/codegen.rs
@@ -1,9 +1,7 @@
-use crate::config::Config;
-use crate::format_arg;
+use crate::{config::Config, errors::WrappedError, format_arg};
 use log::*;
 use spatialos_sdk_code_generator::{generator, schema_bundle};
 use std::{
-    error::Error,
     fmt::{Display, Formatter},
     fs::{self, File},
     io::prelude::*,
@@ -12,46 +10,21 @@ use std::{
 };
 
 #[derive(Debug)]
-pub enum CodegenErrorKind {
+pub enum ErrorKind {
     BadConfig,
     SchemaCompiler,
     InvalidBundle,
     IO,
 }
 
-impl Display for CodegenErrorKind {
+impl Display for ErrorKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            CodegenErrorKind::BadConfig => f.write_str("Bad Config"),
-            CodegenErrorKind::SchemaCompiler => f.write_str("Schema Compiler Error"),
-            CodegenErrorKind::InvalidBundle => f.write_str("Invalid Schema Bundle"),
-            CodegenErrorKind::IO => f.write_str("IO Error"),
+            ErrorKind::BadConfig => f.write_str("Bad Config"),
+            ErrorKind::SchemaCompiler => f.write_str("Schema Compiler Error"),
+            ErrorKind::InvalidBundle => f.write_str("Invalid Schema Bundle"),
+            ErrorKind::IO => f.write_str("IO Error"),
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct CodegenError {
-    kind: CodegenErrorKind,
-    msg: String,
-    inner: Option<Box<dyn Error>>,
-}
-
-impl Display for CodegenError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        let mut msg = format!("{}: {}", self.kind, self.msg);
-
-        if let Some(ref inner) = self.inner {
-            msg = format!("{}\nInner error: {}", msg, inner);
-        }
-
-        f.write_str(&msg)
-    }
-}
-
-impl Error for CodegenError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.inner.as_ref().map(|e| e.as_ref())
     }
 }
 
@@ -59,11 +32,11 @@ impl Error for CodegenError {
 ///
 /// Assumes that the current working directory is the root directory of the project,
 /// i.e. the directory that has the `Spatial.toml` file.
-pub fn run_codegen(config: &Config) -> Result<(), CodegenError> {
+pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
     if !crate::current_dir_is_root() {
-        return Err(CodegenError {
+        return Err(WrappedError {
             msg: "Current directory should be the project root.".into(),
-            kind: CodegenErrorKind::BadConfig,
+            kind: ErrorKind::BadConfig,
             inner: None,
         });
     }
@@ -71,9 +44,9 @@ pub fn run_codegen(config: &Config) -> Result<(), CodegenError> {
     // Ensure that the path to the Spatial SDK has been specified.
     let spatial_lib_dir = config.spatial_lib_dir()
         .map(PathBuf::from)
-        .ok_or(CodegenError {
+        .ok_or(WrappedError {
             msg: "spatial_lib_dir value must be set in the config, or the SPATIAL_LIB_DIR environment variable must be set.".into(),
-            kind: CodegenErrorKind::BadConfig,
+            kind: ErrorKind::BadConfig,
             inner: None})?;
 
     // Determine the paths the the schema compiler and protoc relative the the lib
@@ -89,9 +62,9 @@ pub fn run_codegen(config: &Config) -> Result<(), CodegenError> {
     // Create the output directory if it doesn't already exist.
     fs::create_dir_all(&output_dir).map_err(|e| {
         let msg = format!("Failed to create {}", output_dir.display());
-        CodegenError {
+        WrappedError {
             msg,
-            kind: CodegenErrorKind::IO,
+            kind: ErrorKind::IO,
             inner: Some(Box::new(e)),
         }
     })?;
@@ -121,55 +94,55 @@ pub fn run_codegen(config: &Config) -> Result<(), CodegenError> {
     }
 
     trace!("{:#?}", command);
-    let status = command.status().map_err(|e| CodegenError {
+    let status = command.status().map_err(|e| WrappedError {
         msg: "Failed to compile schema files".into(),
-        kind: CodegenErrorKind::SchemaCompiler,
+        kind: ErrorKind::SchemaCompiler,
         inner: Some(Box::new(e)),
     })?;
 
     if !status.success() {
-        return Err(CodegenError {
+        return Err(WrappedError {
             msg: "Failed to run schema compilation".into(),
-            kind: CodegenErrorKind::SchemaCompiler,
+            kind: ErrorKind::SchemaCompiler,
             inner: None,
         });
     }
 
     // Load bundle.json, which describes the schema definitions for all components.
-    let mut input_file = File::open(&bundle_json_path).map_err(|e| CodegenError {
+    let mut input_file = File::open(&bundle_json_path).map_err(|e| WrappedError {
         msg: "Failed to open bundle.json".into(),
-        kind: CodegenErrorKind::SchemaCompiler,
+        kind: ErrorKind::SchemaCompiler,
         inner: Some(Box::new(e)),
     })?;
 
     let mut contents = String::new();
     input_file
         .read_to_string(&mut contents)
-        .map_err(|e| CodegenError {
+        .map_err(|e| WrappedError {
             msg: "Failed to read contents of bundle.json".into(),
-            kind: CodegenErrorKind::IO,
+            kind: ErrorKind::IO,
             inner: Some(Box::new(e)),
         })?;
 
     // Run code generation.
-    let bundle = schema_bundle::load_bundle(&contents).map_err(|e| CodegenError {
+    let bundle = schema_bundle::load_bundle(&contents).map_err(|e| WrappedError {
         msg: "Failed to parse contents of bundle.json".into(),
-        kind: CodegenErrorKind::InvalidBundle,
+        kind: ErrorKind::InvalidBundle,
         inner: Some(Box::new(e)),
     })?;
     let generated_file = generator::generate_code(bundle);
 
     // Write the generated code to the output file.
     File::create(&config.codegen_out)
-        .map_err(|e| CodegenError {
+        .map_err(|e| WrappedError {
             msg: "Unable to create codegen output file".into(),
-            kind: CodegenErrorKind::IO,
+            kind: ErrorKind::IO,
             inner: Some(Box::new(e)),
         })?
         .write_all(generated_file.as_bytes())
-        .map_err(|e| CodegenError {
+        .map_err(|e| WrappedError {
             msg: "Failed to write generated code to file".into(),
-            kind: CodegenErrorKind::IO,
+            kind: ErrorKind::IO,
             inner: Some(Box::new(e)),
         })?;
 

--- a/cargo-spatial/src/codegen.rs
+++ b/cargo-spatial/src/codegen.rs
@@ -1,4 +1,4 @@
-use crate::{config::Config, errors::WrappedError, format_arg};
+use crate::{config::Config, errors::Error, format_arg};
 use log::*;
 use spatialos_sdk_code_generator::{generator, schema_bundle};
 use std::{
@@ -32,9 +32,9 @@ impl Display for ErrorKind {
 ///
 /// Assumes that the current working directory is the root directory of the project,
 /// i.e. the directory that has the `Spatial.toml` file.
-pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
+pub fn run_codegen(config: &Config) -> Result<(), Error<ErrorKind>> {
     if !crate::current_dir_is_root() {
-        return Err(WrappedError {
+        return Err(Error {
             msg: "Current directory should be the project root.".into(),
             kind: ErrorKind::BadConfig,
             inner: None,
@@ -44,7 +44,7 @@ pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
     // Ensure that the path to the Spatial SDK has been specified.
     let spatial_lib_dir = config.spatial_lib_dir()
         .map(PathBuf::from)
-        .ok_or(WrappedError {
+        .ok_or(Error {
             msg: "spatial_lib_dir value must be set in the config, or the SPATIAL_LIB_DIR environment variable must be set.".into(),
             kind: ErrorKind::BadConfig,
             inner: None})?;
@@ -62,7 +62,7 @@ pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
     // Create the output directory if it doesn't already exist.
     fs::create_dir_all(&output_dir).map_err(|e| {
         let msg = format!("Failed to create {}", output_dir.display());
-        WrappedError {
+        Error {
             msg,
             kind: ErrorKind::IO,
             inner: Some(Box::new(e)),
@@ -94,14 +94,14 @@ pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
     }
 
     trace!("{:#?}", command);
-    let status = command.status().map_err(|e| WrappedError {
+    let status = command.status().map_err(|e| Error {
         msg: "Failed to compile schema files".into(),
         kind: ErrorKind::SchemaCompiler,
         inner: Some(Box::new(e)),
     })?;
 
     if !status.success() {
-        return Err(WrappedError {
+        return Err(Error {
             msg: "Failed to run schema compilation".into(),
             kind: ErrorKind::SchemaCompiler,
             inner: None,
@@ -109,7 +109,7 @@ pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
     }
 
     // Load bundle.json, which describes the schema definitions for all components.
-    let mut input_file = File::open(&bundle_json_path).map_err(|e| WrappedError {
+    let mut input_file = File::open(&bundle_json_path).map_err(|e| Error {
         msg: "Failed to open bundle.json".into(),
         kind: ErrorKind::SchemaCompiler,
         inner: Some(Box::new(e)),
@@ -118,14 +118,14 @@ pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
     let mut contents = String::new();
     input_file
         .read_to_string(&mut contents)
-        .map_err(|e| WrappedError {
+        .map_err(|e| Error {
             msg: "Failed to read contents of bundle.json".into(),
             kind: ErrorKind::IO,
             inner: Some(Box::new(e)),
         })?;
 
     // Run code generation.
-    let bundle = schema_bundle::load_bundle(&contents).map_err(|e| WrappedError {
+    let bundle = schema_bundle::load_bundle(&contents).map_err(|e| Error {
         msg: "Failed to parse contents of bundle.json".into(),
         kind: ErrorKind::InvalidBundle,
         inner: Some(Box::new(e)),
@@ -134,13 +134,13 @@ pub fn run_codegen(config: &Config) -> Result<(), WrappedError<ErrorKind>> {
 
     // Write the generated code to the output file.
     File::create(&config.codegen_out)
-        .map_err(|e| WrappedError {
+        .map_err(|e| Error {
             msg: "Unable to create codegen output file".into(),
             kind: ErrorKind::IO,
             inner: Some(Box::new(e)),
         })?
         .write_all(generated_file.as_bytes())
-        .map_err(|e| WrappedError {
+        .map_err(|e| Error {
             msg: "Failed to write generated code to file".into(),
             kind: ErrorKind::IO,
             inner: Some(Box::new(e)),

--- a/cargo-spatial/src/config.rs
+++ b/cargo-spatial/src/config.rs
@@ -90,12 +90,10 @@ impl Config {
     /// Returns the absolute path to the spatial SDK directory, or `None` if the path hasn't
     /// been configured.
     pub fn spatial_lib_dir(&self) -> Option<String> {
-        match self.spatial_lib_dir {
-            Some(ref path) => Some(self.resolve_path(path)),
-            None => ::std::env::var("SPATIAL_LIB_DIR")
-                .ok()
-                .map(|env_var| self.resolve_path(&env_var)),
-        }
+        self.spatial_lib_dir
+            .clone()
+            .or_else(|| ::std::env::var("SPATIAL_LIB_DIR").ok())
+            .map(|ref path| self.resolve_path(path))
     }
 
     /// Resolves the unresolved path into an absolute path.

--- a/cargo-spatial/src/errors.rs
+++ b/cargo-spatial/src/errors.rs
@@ -1,15 +1,14 @@
 use serde::export::Formatter;
-use std::error::Error;
 use std::fmt::{Debug, Display};
 
 #[derive(Debug)]
-pub struct WrappedError<T: Display + Debug> {
+pub struct Error<T: Display + Debug> {
     pub kind: T,
     pub msg: String,
-    pub inner: Option<Box<dyn Error>>,
+    pub inner: Option<Box<dyn std::error::Error>>,
 }
 
-impl<T: Display + Debug> Display for WrappedError<T> {
+impl<T: Display + Debug> Display for Error<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let mut msg = format!("{}: {}", self.kind, self.msg);
 
@@ -21,8 +20,8 @@ impl<T: Display + Debug> Display for WrappedError<T> {
     }
 }
 
-impl<T: Display + Debug> Error for WrappedError<T> {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+impl<T: Display + Debug> std::error::Error for Error<T> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.inner.as_ref().map(|e| e.as_ref())
     }
 }

--- a/cargo-spatial/src/errors.rs
+++ b/cargo-spatial/src/errors.rs
@@ -1,0 +1,28 @@
+use serde::export::Formatter;
+use std::error::Error;
+use std::fmt::{Debug, Display};
+
+#[derive(Debug)]
+pub struct WrappedError<T: Display + Debug> {
+    pub kind: T,
+    pub msg: String,
+    pub inner: Option<Box<dyn Error>>,
+}
+
+impl<T: Display + Debug> Display for WrappedError<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let mut msg = format!("{}: {}", self.kind, self.msg);
+
+        if let Some(ref inner) = self.inner {
+            msg = format!("{}\nInner error: {}", msg, inner);
+        }
+
+        f.write_str(&msg)
+    }
+}
+
+impl<T: Display + Debug> Error for WrappedError<T> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.inner.as_ref().map(|e| e.as_ref())
+    }
+}

--- a/cargo-spatial/src/lib.rs
+++ b/cargo-spatial/src/lib.rs
@@ -3,6 +3,7 @@ use std::ffi::{OsStr, OsString};
 pub mod codegen;
 pub mod config;
 pub mod download;
+pub mod errors;
 pub mod local;
 pub mod opt;
 

--- a/cargo-spatial/src/local.rs
+++ b/cargo-spatial/src/local.rs
@@ -1,22 +1,46 @@
 use crate::config::{BuildProfile, Config};
+use crate::errors::WrappedError;
 use crate::format_arg;
 use crate::opt::*;
+use serde::export::Formatter;
+use std::fmt::Display;
 use std::path::*;
 use std::process;
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    Codegen,
+    Build,
+    Launch,
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            ErrorKind::Codegen => f.write_str("Codegen Error"),
+            ErrorKind::Build => f.write_str("Build Error"),
+            ErrorKind::Launch => f.write_str("Launch Error"),
+        }
+    }
+}
 
 /// Prepares and launches a local deployment.
 ///
 /// Before launching the deployment, this will first run code generation and build
 /// workers in the project. Assumes that the current working directory is the root
 /// directory of the project, i.e. the directory that has the `Spatial.toml` file.
-pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Box<dyn std::error::Error>> {
+pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), WrappedError<ErrorKind>> {
     assert!(
         crate::current_dir_is_root(),
         "Current directory should be the project root"
     );
 
     // Run codegen and such.
-    crate::codegen::run_codegen(config)?;
+    crate::codegen::run_codegen(config).map_err(|e| WrappedError {
+        kind: ErrorKind::Codegen,
+        msg: "Failed to generate code".into(),
+        inner: Some(Box::new(e)),
+    })?;
 
     // Use `cargo install` to build workers and copy the exectuables to the build
     // directory.
@@ -44,12 +68,18 @@ pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Box<dyn std::
                 command.arg("--debug");
             }
 
-            let status = command
-                .status()
-                .map_err(|err| format!("Failed to build worker binaries: {}", err))?;
+            let status = command.status().map_err(|e| WrappedError {
+                kind: ErrorKind::Build,
+                msg: "Failed to execute 'cargo install'.".into(),
+                inner: Some(Box::new(e)),
+            })?;
 
             if !status.success() {
-                return Err("An error occurred while building workers".into());
+                return Err(WrappedError {
+                    kind: ErrorKind::Build,
+                    msg: "Failed to build worker.".into(),
+                    inner: None,
+                });
             }
         }
     }
@@ -60,9 +90,12 @@ pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Box<dyn std::
     if let Some(launch_config) = &launch.launch_config {
         command.arg(&format_arg("launch_config", launch_config));
     }
-    command
-        .status()
-        .map_err(|err| format!("Failed to run `spatial local launch`: {}", err))?;
+
+    command.status().map_err(|err| WrappedError {
+        kind: ErrorKind::Launch,
+        msg: "Failed to launch deployment.".into(),
+        inner: Some(Box::new(err)),
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
Following on from #139, this PR implements the same approach for the rest of the commands. In doing so, we generalise the error struct into its own module.

