### PR TITLE
Add schema `Entity` type

### DIFF
--- a/project-example/schema/example.schema
+++ b/project-example/schema/example.schema
@@ -54,3 +54,9 @@ component EnumTestComponent {
 
     TestEnum test = 1;
 }
+
+component EntityTest {
+    id = 2003;
+
+    Entity entity = 1;
+}

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -237,6 +237,106 @@ impl Component for EntityIdTest {
 }
 
 #[derive(Debug, Clone)]
+pub struct EntityTest {
+    pub entity: spatialos_sdk::worker::entity::Entity,
+}
+
+impl ObjectField for EntityTest {
+    fn from_object(input: &SchemaObject) -> Result<Self> {
+        Ok(Self {
+            entity: input.get::<SchemaEntity>(1).map_err(Error::at_field::<Self>(1))?,
+        })
+    }
+
+    fn into_object(&self, output: &mut SchemaObject) {
+        output.add::<SchemaEntity>(1, &self.entity);
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EntityTestUpdate {
+    pub entity: Option<spatialos_sdk::worker::entity::Entity>,
+}
+
+impl Update for EntityTestUpdate {
+    type Component = EntityTest;
+
+    fn from_schema(update: &SchemaComponentUpdate) -> Result<Self> {
+        Ok(Self {
+            entity: update.get_field::<SchemaEntity>(1).map_err(Error::at_field::<Self>(1))?,
+        })
+    }
+
+    fn into_schema(&self, update: &mut SchemaComponentUpdate) {
+        update.add_field::<SchemaEntity>(1, &self.entity);
+    }
+
+    fn merge(&mut self, update: Self) {
+        if update.entity.is_some() { self.entity = update.entity; }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum EntityTestCommandRequest {
+}
+
+#[derive(Debug, Clone)]
+pub enum EntityTestCommandResponse {
+}
+
+impl Component for EntityTest {
+    type Update = EntityTestUpdate;
+    type CommandRequest = generated::example::EntityTestCommandRequest;
+    type CommandResponse = generated::example::EntityTestCommandResponse;
+
+    const ID: ComponentId = 2003;
+
+    fn merge_update(&mut self, update: Self::Update) {
+        if let Some(value) = update.entity { self.entity = value; }
+    }
+
+    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::EntityTestCommandRequest> {
+        match command_index {
+            _ => Err(Error::unknown_command::<Self>(command_index))
+        }
+    }
+
+    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::example::EntityTestCommandResponse> {
+        match command_index {
+            _ => Err(Error::unknown_command::<Self>(command_index))
+        }
+    }
+
+    fn to_request(request: &generated::example::EntityTestCommandRequest) -> Owned<SchemaCommandRequest> {
+        let mut serialized_request = SchemaCommandRequest::new();
+        match request {
+            _ => unreachable!()
+        }
+        serialized_request
+    }
+
+    fn to_response(response: &generated::example::EntityTestCommandResponse) -> Owned<SchemaCommandResponse> {
+        let mut serialized_response = SchemaCommandResponse::new();
+        match response {
+            _ => unreachable!()
+        }
+        serialized_response
+    }
+
+    fn get_request_command_index(request: &generated::example::EntityTestCommandRequest) -> u32 {
+        match request {
+            _ => unreachable!(),
+        }
+    }
+
+    fn get_response_command_index(response: &generated::example::EntityTestCommandResponse) -> u32 {
+        match response {
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct EnumTestComponent {
     pub test: generated::example::TestEnum,
 }

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -67,6 +67,21 @@ fn logic_loop(c: &mut WorkerConnection) {
     builder.set_metadata("Rotator", "rusty");
     builder.set_entity_acl_write_access("rusty");
 
+    let mut inner_builder = EntityBuilder::new(0.0, 0.0, 0.0, "rusty");
+    inner_builder.add_component(
+        example::EntityIdTest {
+            eid: EntityId { id: 10 },
+        },
+        "rusty",
+    );
+
+    builder.add_component(
+        example::EntityTest {
+            entity: inner_builder.build().unwrap(),
+        },
+        "rusty",
+    );
+
     let entity = builder.build().unwrap();
 
     let create_request_id = c.send_create_entity_request(entity, None, None);

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -23,7 +23,7 @@ fn primitive_type_name(primitive_type: &PrimitiveType) -> &'static str {
         PrimitiveType::Double => "SchemaDouble",
         PrimitiveType::String => "SchemaString",
         PrimitiveType::EntityId => "SchemaEntityId",
-        PrimitiveType::Entity => panic!("Entity serialization unimplemented."),
+        PrimitiveType::Entity => "SchemaEntity",
         PrimitiveType::Bytes => "SchemaBytes",
     }
 }
@@ -176,7 +176,7 @@ impl Package {
                 PrimitiveType::Double => "f64",
                 PrimitiveType::String => "String",
                 PrimitiveType::EntityId => "spatialos_sdk::worker::EntityId",
-                PrimitiveType::Entity => panic!("Entity serialization unimplemented."),
+                PrimitiveType::Entity => "spatialos_sdk::worker::entity::Entity",
                 PrimitiveType::Bytes => "Vec<u8>",
             }
             .to_string(),

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -61,7 +61,9 @@ impl Entity {
     pub(crate) fn to_schema_field(&self, object: &mut SchemaObject) {
         for (component_id, data) in &self.components {
             let component_field = object.add_object(*component_id);
-            component_field.copy_from(data.fields()).unwrap(); // TODO: Get rid of unwrap.
+            component_field
+                .copy_from(data.fields())
+                .expect("Schema object copy failed unexpectedly.");
         }
     }
 

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -384,6 +384,13 @@ impl Error {
             },
         }
     }
+
+    pub fn schema_error<T>(msg: String) -> Self {
+        Self {
+            type_name: std::any::type_name::<T>(),
+            kind: ErrorKind::SchemaError(msg),
+        }
+    }
 }
 
 impl Display for Error {
@@ -426,6 +433,8 @@ impl Display for Error {
                     field, self.type_name, error
                 ),
             },
+
+            ErrorKind::SchemaError(msg) => write!(f, "Generic schema error {}", msg),
         }
     }
 }
@@ -463,4 +472,5 @@ pub enum ErrorKind {
         index: Option<usize>,
         error: Box<Error>,
     },
+    SchemaError(String),
 }

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -1,4 +1,5 @@
 use crate::worker::schema::{DataPointer, Field, FieldId, IndexedField, Result};
+use crate::worker::utils::cstr_to_string;
 use spatialos_sdk_sys::worker::*;
 use std::marker::PhantomData;
 
@@ -60,6 +61,26 @@ impl SchemaObject {
             Schema_GetUniqueFieldIds(self.as_ptr(), buffer.as_mut_ptr());
             buffer
         }
+    }
+
+    pub fn copy_from(&mut self, other: &SchemaObject) -> std::result::Result<(), String> {
+        unsafe {
+            let length = Schema_GetWriteBufferLength(other.as_ptr());
+            let buffer = Schema_AllocateBuffer(self.as_ptr_mut(), length);
+            let result = Schema_SerializeToBuffer(other.as_ptr(), buffer, length);
+
+            if result == 0 {
+                return Err(cstr_to_string(Schema_GetError(other.as_ptr())));
+            }
+
+            let result = Schema_MergeFromBuffer(self.as_ptr_mut(), buffer, length);
+
+            if result == 0 {
+                return Err(cstr_to_string(Schema_GetError(self.as_ptr())));
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/spatialos-sdk/src/worker/schema/object.rs
+++ b/spatialos-sdk/src/worker/schema/object.rs
@@ -52,6 +52,15 @@ impl SchemaObject {
     pub fn add_object(&mut self, field: FieldId) -> &mut SchemaObject {
         unsafe { Self::from_raw_mut(Schema_AddObject(self.as_ptr_mut(), field)) }
     }
+
+    pub fn unique_field_ids(&self) -> Vec<FieldId> {
+        unsafe {
+            let count = Schema_GetUniqueFieldIdCount(self.as_ptr());
+            let mut buffer = Vec::with_capacity(count as usize);
+            Schema_GetUniqueFieldIds(self.as_ptr(), buffer.as_mut_ptr());
+            buffer
+        }
+    }
 }
 
 unsafe impl DataPointer for SchemaObject {


### PR DESCRIPTION
This PR adds the schema `entity` type. This corresponds to the `worker::entity::Entity` struct in Rust.

This schema type is structured like:

```
entity field
	field id 54 --> SchemaObject (position_component)
	field id 100 -> SchemaObject (some_component)
	...
```

such that a component is de/serialized from/to the field ID that corresponds to that component ID. We expose two new methods in the `VTable` struct to accommodate this structure which allow us to (de)serialize directly to/from the `SchemaObject`.

---

This PR also has a assorted set of changes to support this schema type.

- The `Component` trait requires `Clone` such that we can deep copy the `Entity` object. (The worker vtable "copy" is only a shallow copy). 
- Some convenience methods for mutating the `Entity` object.
- Exposing `unique_field_ids` on the `SchemaObject` type