### PR TITLE
Flexible component update sending

### DIFF
--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -173,7 +173,7 @@ fn logic_loop(c: &mut WorkerConnection) {
 
                 // Send an update to SpatialOS to apply the same update to the official component
                 // state.
-                c.send_component_update::<example::Rotate>(
+                c.send_component_update(
                     entity_id,
                     &example::RotateUpdate {
                         angle: Some(rotate.angle),
@@ -184,7 +184,7 @@ fn logic_loop(c: &mut WorkerConnection) {
 
                 // Update the entity's position based on the current state of the `Rotate`
                 // component.
-                c.send_component_update::<improbable::Position>(
+                c.send_component_update(
                     entity_id,
                     &improbable::PositionUpdate {
                         coords: Some(improbable::Coordinates {

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -1,4 +1,5 @@
 use crate::ptr::MutPtr;
+use crate::worker::component::ComponentUpdate;
 use crate::worker::{
     commands::*,
     component::{Component, UpdateParameters},
@@ -7,7 +8,6 @@ use crate::worker::{
     metrics::Metrics,
     op::OpList,
     parameters::ConnectionParameters,
-    schema::*,
     utils::cstr_to_string,
     worker_future::{WorkerFuture, WorkerSdkFuture},
     {EntityId, InterestOverride, LogLevel, RequestId},
@@ -185,10 +185,10 @@ pub trait Connection {
         message: &str,
     ) -> Result<(), NulError>;
 
-    fn send_component_update<C: Component>(
+    fn send_component_update<T: Into<ComponentUpdate>>(
         &mut self,
         entity_id: EntityId,
-        update: &C::Update,
+        update: T,
         parameters: UpdateParameters,
     );
 
@@ -481,16 +481,17 @@ impl Connection for WorkerConnection {
         Ok(())
     }
 
-    fn send_component_update<C: Component>(
+    fn send_component_update<T: Into<ComponentUpdate>>(
         &mut self,
         entity_id: EntityId,
-        update: &C::Update,
+        update: T,
         parameters: UpdateParameters,
     ) {
+        let update = update.into();
         let mut component_update = Worker_ComponentUpdate {
             reserved: ptr::null_mut(),
-            component_id: C::ID,
-            schema_type: SchemaComponentUpdate::from_update(update).into_raw(),
+            component_id: update.component_id,
+            schema_type: update.schema_data.into_raw(),
             user_handle: ptr::null_mut(),
         };
 


### PR DESCRIPTION
This PR introduces an intermediate abstraction for sending component updates that the `Connection` trait understands. 

The rationale for adding this abstraction is to allow manually created update objects to be sent along with generated update structs:

```rust
let schema_update = SchemaComponentUpdate::new();
let update = ComponentUpdate { schema_data: schema_update, component_id: 54 };
connection.send_component_update(EntityId(5), update, UpdateParams{});

let generated_update = PositionUpdate::default();
connection.send_component_update(EntityId(5), update, UpdateParams{});
```

We can add a similar pattern to commands when the traits for those are finished 😄. This would decouple the `Connection` trait from the `Component`/`Update`/`CommandRequest/Response` traits (and thus generated code) which will help with #83.