### PR TITLE
Remove generic type from `RequestId`

### DIFF
--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -330,11 +330,11 @@ impl Connection for WorkerConnection {
                 Some(c) => &c,
                 None => ptr::null(),
             };
-            Worker_Connection_SendReserveEntityIdsRequest(
+            RequestId::new(Worker_Connection_SendReserveEntityIdsRequest(
                 self.connection_ptr.get(),
                 payload.0,
                 timeout,
-            )
+            ))
         }
     }
 
@@ -354,13 +354,13 @@ impl Connection for WorkerConnection {
         };
         let mut component_data = entity.into_raw();
         unsafe {
-            Worker_Connection_SendCreateEntityRequest(
+            RequestId::new(Worker_Connection_SendCreateEntityRequest(
                 self.connection_ptr.get(),
                 component_data.len() as _,
                 component_data.as_mut_ptr(),
                 entity_id,
                 timeout,
-            )
+            ))
         }
     }
 
@@ -374,11 +374,11 @@ impl Connection for WorkerConnection {
                 Some(c) => &c,
                 None => ptr::null(),
             };
-            Worker_Connection_SendDeleteEntityRequest(
+            RequestId::new(Worker_Connection_SendDeleteEntityRequest(
                 self.connection_ptr.get(),
                 payload.0.id,
                 timeout,
-            )
+            ))
         }
     }
 
@@ -394,11 +394,11 @@ impl Connection for WorkerConnection {
             };
 
             let worker_query = payload.0.to_worker_sdk();
-            Worker_Connection_SendEntityQueryRequest(
+            RequestId::new(Worker_Connection_SendEntityQueryRequest(
                 self.connection_ptr.get(),
                 &worker_query.query,
                 timeout,
-            )
+            ))
         }
     }
 
@@ -425,13 +425,13 @@ impl Connection for WorkerConnection {
         };
 
         unsafe {
-            Worker_Connection_SendCommandRequest(
+            RequestId::new(Worker_Connection_SendCommandRequest(
                 self.connection_ptr.get(),
                 entity_id.id,
                 &mut command_request,
                 timeout,
                 &params.to_worker_sdk(),
-            )
+            ))
         }
     }
 
@@ -451,7 +451,7 @@ impl Connection for WorkerConnection {
         unsafe {
             Worker_Connection_SendCommandResponse(
                 self.connection_ptr.get(),
-                request_id,
+                request_id.id,
                 &mut raw_response,
             );
         }
@@ -466,7 +466,7 @@ impl Connection for WorkerConnection {
         unsafe {
             Worker_Connection_SendCommandFailure(
                 self.connection_ptr.get(),
-                request_id,
+                request_id.id,
                 message.as_ptr(),
             );
         }

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -147,23 +147,23 @@ pub trait Connection {
         &mut self,
         payload: ReserveEntityIdsRequest,
         timeout_millis: Option<u32>,
-    ) -> RequestId<ReserveEntityIdsRequest>;
+    ) -> RequestId;
     fn send_create_entity_request(
         &mut self,
         entity: Entity,
         entity_id: Option<EntityId>,
         timeout_millis: Option<u32>,
-    ) -> RequestId<CreateEntityRequest>;
+    ) -> RequestId;
     fn send_delete_entity_request(
         &mut self,
         payload: DeleteEntityRequest,
         timeout_millis: Option<u32>,
-    ) -> RequestId<DeleteEntityRequest>;
+    ) -> RequestId;
     fn send_entity_query_request(
         &mut self,
         payload: EntityQueryRequest,
         timeout_millis: Option<u32>,
-    ) -> RequestId<EntityQueryRequest>;
+    ) -> RequestId;
 
     fn send_command_request<C: Component>(
         &mut self,
@@ -171,17 +171,17 @@ pub trait Connection {
         request: &C::CommandRequest,
         timeout_millis: Option<u32>,
         params: CommandParameters,
-    ) -> RequestId<OutgoingCommandRequest>;
+    ) -> RequestId;
 
     fn send_command_response<C: Component>(
         &mut self,
-        request_id: RequestId<IncomingCommandRequest>,
+        request_id: RequestId,
         response: &C::CommandResponse,
     );
 
     fn send_command_failure(
         &mut self,
-        request_id: RequestId<IncomingCommandRequest>,
+        request_id: RequestId,
         message: &str,
     ) -> Result<(), NulError>;
 
@@ -324,18 +324,17 @@ impl Connection for WorkerConnection {
         &mut self,
         payload: ReserveEntityIdsRequest,
         timeout_millis: Option<u32>,
-    ) -> RequestId<ReserveEntityIdsRequest> {
+    ) -> RequestId {
         unsafe {
             let timeout = match timeout_millis {
                 Some(c) => &c,
                 None => ptr::null(),
             };
-            let id = Worker_Connection_SendReserveEntityIdsRequest(
+            Worker_Connection_SendReserveEntityIdsRequest(
                 self.connection_ptr.get(),
                 payload.0,
                 timeout,
-            );
-            RequestId::new(id)
+            )
         }
     }
 
@@ -344,7 +343,7 @@ impl Connection for WorkerConnection {
         entity: Entity,
         entity_id: Option<EntityId>,
         timeout_millis: Option<u32>,
-    ) -> RequestId<CreateEntityRequest> {
+    ) -> RequestId {
         let timeout = match timeout_millis {
             Some(c) => &c,
             None => ptr::null(),
@@ -354,7 +353,7 @@ impl Connection for WorkerConnection {
             None => ptr::null(),
         };
         let mut component_data = entity.into_raw();
-        let id = unsafe {
+        unsafe {
             Worker_Connection_SendCreateEntityRequest(
                 self.connection_ptr.get(),
                 component_data.len() as _,
@@ -362,27 +361,24 @@ impl Connection for WorkerConnection {
                 entity_id,
                 timeout,
             )
-        };
-
-        RequestId::new(id)
+        }
     }
 
     fn send_delete_entity_request(
         &mut self,
         payload: DeleteEntityRequest,
         timeout_millis: Option<u32>,
-    ) -> RequestId<DeleteEntityRequest> {
+    ) -> RequestId {
         unsafe {
             let timeout = match timeout_millis {
                 Some(c) => &c,
                 None => ptr::null(),
             };
-            let id = Worker_Connection_SendDeleteEntityRequest(
+            Worker_Connection_SendDeleteEntityRequest(
                 self.connection_ptr.get(),
                 payload.0.id,
                 timeout,
-            );
-            RequestId::new(id)
+            )
         }
     }
 
@@ -390,7 +386,7 @@ impl Connection for WorkerConnection {
         &mut self,
         payload: EntityQueryRequest,
         timeout_millis: Option<u32>,
-    ) -> RequestId<EntityQueryRequest> {
+    ) -> RequestId {
         unsafe {
             let timeout = match timeout_millis {
                 Some(c) => &c,
@@ -398,12 +394,11 @@ impl Connection for WorkerConnection {
             };
 
             let worker_query = payload.0.to_worker_sdk();
-            let id = Worker_Connection_SendEntityQueryRequest(
+            Worker_Connection_SendEntityQueryRequest(
                 self.connection_ptr.get(),
                 &worker_query.query,
                 timeout,
-            );
-            RequestId::new(id)
+            )
         }
     }
 
@@ -413,7 +408,7 @@ impl Connection for WorkerConnection {
         request: &C::CommandRequest,
         timeout_millis: Option<u32>,
         params: CommandParameters,
-    ) -> RequestId<OutgoingCommandRequest> {
+    ) -> RequestId {
         let command_index = C::get_request_command_index(&request);
 
         let timeout = match timeout_millis {
@@ -429,7 +424,7 @@ impl Connection for WorkerConnection {
             user_handle: ptr::null_mut(),
         };
 
-        let request_id = unsafe {
+        unsafe {
             Worker_Connection_SendCommandRequest(
                 self.connection_ptr.get(),
                 entity_id.id,
@@ -437,14 +432,12 @@ impl Connection for WorkerConnection {
                 timeout,
                 &params.to_worker_sdk(),
             )
-        };
-
-        RequestId::new(request_id)
+        }
     }
 
     fn send_command_response<C: Component>(
         &mut self,
-        request_id: RequestId<IncomingCommandRequest>,
+        request_id: RequestId,
         response: &C::CommandResponse,
     ) {
         let mut raw_response = Worker_CommandResponse {
@@ -458,7 +451,7 @@ impl Connection for WorkerConnection {
         unsafe {
             Worker_Connection_SendCommandResponse(
                 self.connection_ptr.get(),
-                request_id.id,
+                request_id,
                 &mut raw_response,
             );
         }
@@ -466,14 +459,14 @@ impl Connection for WorkerConnection {
 
     fn send_command_failure(
         &mut self,
-        request_id: RequestId<IncomingCommandRequest>,
+        request_id: RequestId,
         message: &str,
     ) -> Result<(), NulError> {
         let message = CString::new(message)?;
         unsafe {
             Worker_Connection_SendCommandFailure(
                 self.connection_ptr.get(),
-                request_id.id,
+                request_id,
                 message.as_ptr(),
             );
         }

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -14,11 +14,8 @@ pub(crate) mod utils;
 pub mod worker_future;
 
 use component::ComponentId;
-use derivative::Derivative;
 use spatialos_sdk_sys::worker::Worker_InterestOverride;
-use std::cmp::Ordering;
 use std::fmt::{Display, Error, Formatter};
-use std::marker::PhantomData;
 
 // NOTE: This must be `repr(transparent)` in order for it to be ABI-compatible with
 // the C API, which uses a raw `i64` to represent an entity ID. See the comment on
@@ -45,45 +42,7 @@ impl Display for EntityId {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(
-    Debug(bound = ""),
-    Copy(bound = ""),
-    Clone(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = ""),
-    Hash(bound = "")
-)]
-pub struct RequestId<T> {
-    id: i64,
-    _type: PhantomData<*const T>,
-}
-
-impl<T> Ord for RequestId<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.id.cmp(&other.id)
-    }
-}
-
-impl<T> PartialOrd for RequestId<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-// SAFE: `RequestId<T>` is a type-safe wrapper around a single integer value, and is
-// therefore completely thread-safe.
-unsafe impl<T> Send for RequestId<T> {}
-unsafe impl<T> Sync for RequestId<T> {}
-
-impl<T> RequestId<T> {
-    pub fn new(id: i64) -> RequestId<T> {
-        RequestId {
-            id,
-            _type: PhantomData,
-        }
-    }
-}
+type RequestId = i64;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Authority {

--- a/spatialos-sdk/src/worker/mod.rs
+++ b/spatialos-sdk/src/worker/mod.rs
@@ -38,11 +38,26 @@ impl EntityId {
 
 impl Display for EntityId {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(f, "EntityId: {}", self.id)
+        write!(f, "Entity ID {}", self.id)
     }
 }
 
-type RequestId = i64;
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RequestId {
+    pub id: i64,
+}
+
+impl RequestId {
+    pub fn new(id: i64) -> Self {
+        RequestId { id }
+    }
+}
+
+impl Display for RequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "Request ID {}", self.id)
+    }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Authority {

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -1,7 +1,6 @@
 #![allow(non_upper_case_globals)]
 
 use crate::worker::{
-    commands::*,
     component::{self, *},
     entity::Entity,
     metrics::Metrics,
@@ -214,7 +213,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     );
 
                     let command_request_op = CommandRequestOp {
-                        request_id: RequestId::new(op.request_id),
+                        request_id: op.request_id,
                         entity_id: EntityId::new(op.entity_id),
                         timeout_millis: op.timeout_millis,
                         caller_worker_id: cstr_to_string(op.caller_worker_id),
@@ -256,7 +255,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
 
                     let command_response_op = CommandResponseOp {
                         entity_id: EntityId::new(op.entity_id),
-                        request_id: RequestId::new(op.request_id),
+                        request_id: op.request_id,
                         component_id: op.response.component_id,
                         response: status_code,
                     };
@@ -293,7 +292,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let reserve_entity_ids_response_op = ReserveEntityIdsResponseOp {
-                        request_id: RequestId::new(op.request_id),
+                        request_id: op.request_id,
                         status_code,
                     };
                     WorkerOp::ReserveEntityIdsResponse(reserve_entity_ids_response_op)
@@ -329,7 +328,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let create_entity_response_op = CreateEntityResponseOp {
-                        request_id: RequestId::new(op.request_id),
+                        request_id: op.request_id,
                         status_code,
                     };
                     WorkerOp::CreateEntityResponse(create_entity_response_op)
@@ -363,7 +362,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let delete_entity_response_op = DeleteEntityResponseOp {
-                        request_id: RequestId::new(op.request_id),
+                        request_id: op.request_id,
                         entity_id: EntityId::new(op.entity_id),
                         status_code,
                     };
@@ -416,7 +415,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let entity_query_response_op = EntityQueryResponseOp {
-                        request_id: RequestId::new(op.request_id),
+                        request_id: op.request_id,
                         status_code,
                     };
 
@@ -467,7 +466,7 @@ pub struct RemoveEntityOp {
 
 #[derive(Debug)]
 pub struct ReserveEntityIdsResponseOp {
-    pub request_id: RequestId<ReserveEntityIdsRequest>,
+    pub request_id: RequestId,
     pub status_code: StatusCode<ReservedEntityIdRange>,
 }
 
@@ -508,13 +507,13 @@ impl Iterator for ReservedEntityIdRange {
 
 #[derive(Debug)]
 pub struct CreateEntityResponseOp {
-    pub request_id: RequestId<CreateEntityRequest>,
+    pub request_id: RequestId,
     pub status_code: StatusCode<EntityId>,
 }
 
 #[derive(Debug)]
 pub struct DeleteEntityResponseOp {
-    pub request_id: RequestId<DeleteEntityRequest>,
+    pub request_id: RequestId,
     pub entity_id: EntityId,
     pub status_code: StatusCode<()>,
 }
@@ -527,7 +526,7 @@ pub enum QueryResponse {
 
 #[derive(Debug)]
 pub struct EntityQueryResponseOp {
-    pub request_id: RequestId<EntityQueryRequest>,
+    pub request_id: RequestId,
     pub status_code: StatusCode<QueryResponse>,
 }
 
@@ -578,7 +577,7 @@ impl<'a> ComponentUpdateOp<'a> {
 
 #[derive(Debug)]
 pub struct CommandRequestOp<'a> {
-    pub request_id: RequestId<IncomingCommandRequest>,
+    pub request_id: RequestId,
     pub entity_id: EntityId,
     pub timeout_millis: u32,
     pub caller_worker_id: String,
@@ -599,7 +598,7 @@ impl<'a> CommandRequestOp<'a> {
 
 #[derive(Debug)]
 pub struct CommandResponseOp<'a> {
-    pub request_id: RequestId<OutgoingCommandRequest>,
+    pub request_id: RequestId,
     pub entity_id: EntityId,
     pub component_id: ComponentId,
     pub response: StatusCode<CommandResponseRef<'a>>,

--- a/spatialos-sdk/src/worker/op.rs
+++ b/spatialos-sdk/src/worker/op.rs
@@ -213,7 +213,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     );
 
                     let command_request_op = CommandRequestOp {
-                        request_id: op.request_id,
+                        request_id: RequestId::new(op.request_id),
                         entity_id: EntityId::new(op.entity_id),
                         timeout_millis: op.timeout_millis,
                         caller_worker_id: cstr_to_string(op.caller_worker_id),
@@ -255,7 +255,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
 
                     let command_response_op = CommandResponseOp {
                         entity_id: EntityId::new(op.entity_id),
-                        request_id: op.request_id,
+                        request_id: RequestId::new(op.request_id),
                         component_id: op.response.component_id,
                         response: status_code,
                     };
@@ -292,7 +292,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let reserve_entity_ids_response_op = ReserveEntityIdsResponseOp {
-                        request_id: op.request_id,
+                        request_id: RequestId::new(op.request_id),
                         status_code,
                     };
                     WorkerOp::ReserveEntityIdsResponse(reserve_entity_ids_response_op)
@@ -328,7 +328,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let create_entity_response_op = CreateEntityResponseOp {
-                        request_id: op.request_id,
+                        request_id: RequestId::new(op.request_id),
                         status_code,
                     };
                     WorkerOp::CreateEntityResponse(create_entity_response_op)
@@ -362,7 +362,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let delete_entity_response_op = DeleteEntityResponseOp {
-                        request_id: op.request_id,
+                        request_id: RequestId::new(op.request_id),
                         entity_id: EntityId::new(op.entity_id),
                         status_code,
                     };
@@ -415,7 +415,7 @@ impl<'a> From<&'a Worker_Op> for WorkerOp<'a> {
                     };
 
                     let entity_query_response_op = EntityQueryResponseOp {
-                        request_id: op.request_id,
+                        request_id: RequestId::new(op.request_id),
                         status_code,
                     };
 


### PR DESCRIPTION
We used to do this in the C# SDK as well and its not really very helpful. 

Imagine you wanted to store a list of pending requests, you end up needing to type-erase the generic type in them. (I came across this when trying to build a demo and ended up falling back to the inner id)

It also makes the implementation a bit simpler.