### PR TITLE
Remove some lazy_static dependencies

### DIFF
--- a/spatialos-sdk-sys/Cargo.toml
+++ b/spatialos-sdk-sys/Cargo.toml
@@ -10,6 +10,3 @@ links = "worker"
 build = "build.rs"
 
 [dependencies]
-
-[build-dependencies]
-lazy_static = "1.1.0"

--- a/spatialos-sdk-sys/build.rs
+++ b/spatialos-sdk-sys/build.rs
@@ -1,19 +1,10 @@
-#[macro_use]
-extern crate lazy_static;
-
 use std::env;
 use std::path::Path;
 
 #[cfg(windows)]
-lazy_static! {
-    static ref LIBS: Vec<&'static str> =
-        vec!["improbable_worker", "RakNetLibStatic", "ssl", "zlibstatic",];
-}
-
+const LIBS: [&str; 4] = ["improbable_worker", "RakNetLibStatic", "ssl", "zlibstatic"];
 #[cfg(unix)]
-lazy_static! {
-    static ref LIBS: Vec<&'static str> = vec!["improbable_worker", "RakNetLibStatic", "ssl", "z",];
-}
+const LIBS: [&str; 4] = ["improbable_worker", "RakNetLibStatic", "ssl", "z"];
 
 #[cfg(target_os = "linux")]
 static PACKAGE_DIR: &str = "linux";

--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 derivative = "1.0.2"
 futures = "0.3.1"
 spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
-lazy_static = "1.3"
 
 [dev-dependencies]
 static_assertions = "1.1.0"


### PR DESCRIPTION
- The `lazy_static` dependency in `spatialos-sdk` was unused.
- The `lazy_static` build dependency in `spatialos-sdk-sys` was not necessary.