### PR TITLE
Use exhaustive schema package

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: spatial
-          args: --verbose download sdk --sdk-version 14.1.0
+          args: --verbose download sdk --sdk-version 14.1.0 --with-test-schema
         env:
           SPATIAL_LIB_DIR: "dependencies"
 

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: spatial
-          args: --verbose download sdk --sdk-version 14.1.0
+          args: --verbose download sdk --sdk-version 14.1.0 --with-test-schema
         env:
           SPATIAL_LIB_DIR: "dependencies"
 

--- a/.idea/runConfigurations/Download_SDK.xml
+++ b/.idea/runConfigurations/Download_SDK.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Download SDK" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="channel" value="DEFAULT" />
-    <option name="command" value="spatial download sdk --sdk-version 14.1.0" />
+    <option name="command" value="spatial download sdk --sdk-version 14.1.0 --with-test-schema" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
     <option name="emulateTerminal" value="false" />

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To develop in this repository you'll need:
 4. Download the C API dependencies.
    
    ```
-   $ cargo spatial download sdk --sdk-version 14.1.0
+   $ cargo spatial download sdk --sdk-version 14.1.0 --with-test-schema
    ```
 5. Build the `spatialos-sdk` crate.
    

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -5,6 +5,8 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(unused_mut)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::option_option)]
 
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -112,7 +112,7 @@ impl Into<u32> for TestEnum {
 impl_field_for_enum_field!(TestEnum);
 
 /* Types. */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CommandData {
     pub value: i32,
 }
@@ -127,7 +127,7 @@ impl ObjectField for CommandData {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MapTypes {
     pub first: BTreeMap<generated::example::SomeEnum, i32>,
     pub second: BTreeMap<spatialos_sdk::worker::entity::Entity, i32>,
@@ -145,7 +145,7 @@ impl ObjectField for MapTypes {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Recursive {
     pub opt: Option<Box<generated::example::Recursive>>,
 }
@@ -160,7 +160,7 @@ impl ObjectField for Recursive {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TestType {
     pub value: i32,
 }
@@ -175,7 +175,7 @@ impl ObjectField for TestType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TestType_Inner {
     pub number: FloatOrd<f32>,
 }
@@ -190,7 +190,7 @@ impl ObjectField for TestType_Inner {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Vector3d {
     pub x: FloatOrd<f64>,
     pub y: FloatOrd<f64>,
@@ -758,7 +758,7 @@ use super::super::generated as generated;
 
 /* Enums. */
 /* Types. */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest {
     pub queries: Vec<generated::improbable::ComponentInterest_Query>,
 }
@@ -773,7 +773,7 @@ impl ObjectField for ComponentInterest {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_BoxConstraint {
     pub center: generated::improbable::Coordinates,
     pub edge_length: generated::improbable::EdgeLength,
@@ -791,7 +791,7 @@ impl ObjectField for ComponentInterest_BoxConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_CylinderConstraint {
     pub center: generated::improbable::Coordinates,
     pub radius: FloatOrd<f64>,
@@ -809,7 +809,7 @@ impl ObjectField for ComponentInterest_CylinderConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_Query {
     pub constraint: generated::improbable::ComponentInterest_QueryConstraint,
     pub full_snapshot_result: Option<bool>,
@@ -833,7 +833,7 @@ impl ObjectField for ComponentInterest_Query {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_QueryConstraint {
     pub sphere_constraint: Option<generated::improbable::ComponentInterest_SphereConstraint>,
     pub cylinder_constraint: Option<generated::improbable::ComponentInterest_CylinderConstraint>,
@@ -875,7 +875,7 @@ impl ObjectField for ComponentInterest_QueryConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_RelativeBoxConstraint {
     pub edge_length: generated::improbable::EdgeLength,
 }
@@ -890,7 +890,7 @@ impl ObjectField for ComponentInterest_RelativeBoxConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_RelativeCylinderConstraint {
     pub radius: FloatOrd<f64>,
 }
@@ -905,7 +905,7 @@ impl ObjectField for ComponentInterest_RelativeCylinderConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_RelativeSphereConstraint {
     pub radius: FloatOrd<f64>,
 }
@@ -920,7 +920,7 @@ impl ObjectField for ComponentInterest_RelativeSphereConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ComponentInterest_SphereConstraint {
     pub center: generated::improbable::Coordinates,
     pub radius: FloatOrd<f64>,
@@ -938,7 +938,7 @@ impl ObjectField for ComponentInterest_SphereConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Coordinates {
     pub x: FloatOrd<f64>,
     pub y: FloatOrd<f64>,
@@ -959,7 +959,7 @@ impl ObjectField for Coordinates {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EdgeLength {
     pub x: FloatOrd<f64>,
     pub y: FloatOrd<f64>,
@@ -980,7 +980,7 @@ impl ObjectField for EdgeLength {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WorkerAttributeSet {
     pub attribute: Vec<String>,
 }
@@ -995,7 +995,7 @@ impl ObjectField for WorkerAttributeSet {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WorkerRequirementSet {
     pub attribute_set: Vec<generated::improbable::WorkerAttributeSet>,
 }
@@ -1571,7 +1571,7 @@ impl Into<u32> for Connection_ConnectionStatus {
 impl_field_for_enum_field!(Connection_ConnectionStatus);
 
 /* Types. */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Connection {
     pub status: generated::improbable::restricted::Connection_ConnectionStatus,
     pub data_latency_ms: u32,
@@ -1592,7 +1592,7 @@ impl ObjectField for Connection {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DisconnectRequest {
 }
 impl ObjectField for DisconnectRequest {
@@ -1604,7 +1604,7 @@ impl ObjectField for DisconnectRequest {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DisconnectResponse {
 }
 impl ObjectField for DisconnectResponse {
@@ -1616,7 +1616,7 @@ impl ObjectField for DisconnectResponse {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PlayerIdentity {
     pub player_identifier: String,
     pub provider: String,

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -49,7 +49,7 @@ impl Into<u32> for <#= enum_rust_name #> {
 impl_field_for_enum_field!(<#= enum_rust_name #>);
 <# } #>
 /* Types. */<# for type_name in &self.types { let type_def = self.get_type_definition(type_name); #>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct <#= self.rust_name(&type_def.qualified_name) #> {<#
     for field in &type_def.fields {
     #>

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -415,7 +415,8 @@ fn generate_module(package: &Package) -> String {
             "#![allow(dead_code)]",
             "#![allow(non_camel_case_types)]",
             "#![allow(unused_mut)]",
-            "#![allow(unreadable_literal)]"
+            "#![allow(clippy::unreadable_literal)]",
+            "#![allow(clippy::option_option)]"
         ]
         .join("\n");
         format!("{}\n\n{}", allow_warnings, module_contents)

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -416,7 +416,7 @@ fn generate_module(package: &Package) -> String {
             "#![allow(non_camel_case_types)]",
             "#![allow(unused_mut)]",
             "#![allow(clippy::unreadable_literal)]",
-            "#![allow(clippy::option_option)]"
+            "#![allow(clippy::option_option)]",
         ]
         .join("\n");
         format!("{}\n\n{}", allow_warnings, module_contents)

--- a/spatialos-sdk-code-generator/src/generator.rs
+++ b/spatialos-sdk-code-generator/src/generator.rs
@@ -415,6 +415,7 @@ fn generate_module(package: &Package) -> String {
             "#![allow(dead_code)]",
             "#![allow(non_camel_case_types)]",
             "#![allow(unused_mut)]",
+            "#![allow(unreadable_literal)]"
         ]
         .join("\n");
         format!("{}\n\n{}", allow_warnings, module_contents)

--- a/test-suite/Spatial.toml
+++ b/test-suite/Spatial.toml
@@ -1,0 +1,1 @@
+schema_paths = ["../dependencies/test-schema/"]


### PR DESCRIPTION
Opening this PR to track the various issues left in the code generator (as found by the exhaustive schema package).

- [x] Recursive schema options cause compiler errors (infinite size). These should be boxed. => #154 
- [x] Issues around using certain types in maps
	- Seems related to the constraint that the key in the map must implement `Ord` - https://github.com/jamiebrynes7/spatialos-sdk-rs/blob/tests/exhaustive-schema/spatialos-sdk/src/worker/schema/collections.rs#L151
	- Things like generated enums, generated types, schema entity, don't implement `Ord`. 