### PR TITLE
Add recursive schema option support 

### DIFF
--- a/project-example/schema/example.schema
+++ b/project-example/schema/example.schema
@@ -60,3 +60,8 @@ component EntityTest {
 
     Entity entity = 1;
 }
+
+// TODO: Remove when https://github.com/jamiebrynes7/spatialos-sdk-rs/pull/153 is merged.
+type Recursive {
+    option<Recursive> opt = 1;
+}

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -85,6 +85,21 @@ impl ObjectField for CommandData {
 }
 
 #[derive(Debug, Clone)]
+pub struct Recursive {
+    pub opt: Option<Box<generated::example::Recursive>>,
+}
+impl ObjectField for Recursive {
+    fn from_object(input: &SchemaObject) -> Result<Self> {
+        Ok(Self {
+            opt: input.get::<RecursiveOptional<generated::example::Recursive>>(1).map_err(Error::at_field::<Self>(1))?,
+        })
+    }
+    fn into_object(&self, output: &mut SchemaObject) {
+        output.add::<RecursiveOptional<generated::example::Recursive>>(1, &self.opt);
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct TestType {
     pub value: i32,
 }


### PR DESCRIPTION
This PR introduces recursive schema option support. This is an edge case in schemalang where the following is valid schema.

```
type Recursive {
	option<Recursive> opt = 1;
}

type TypeA {
	option<TypeB> opt = 1;
}

type TypeB {
	option<TypeA> opt = 1;
}
```

To support this edge case, we detect when a field is recursive (i.e. - cyclical) and change the type from `Option<T>` to `Option<Box<T>>`. 

To enable this, we add another schema container `RecursiveOptional<T>` which is almost identical to `Optional<T>` except it has an additional trait bound `ObjectField` since only types can be optional _and_ the `RustType` alias has the additional `Box`. 

---

For the above schema this change should now generate:

```rust
struct Recursive {
	pub opt: Option<Box<Recursive>>
}

struct TypeA {
	pub opt: Option<Box<TypeB>>
}

struct TypeB {
	pub opt: Option<Box<TypeA>>
}
```