### PR TITLE
Support enums & schema entity as keys in schema maps

### DIFF
--- a/project-example/schema/example.schema
+++ b/project-example/schema/example.schema
@@ -73,4 +73,5 @@ enum SomeEnum {
 
 type MapTypes {
     map<SomeEnum, int32> first = 1;
+    map<Entity, int32> second = 2;
 }

--- a/project-example/schema/example.schema
+++ b/project-example/schema/example.schema
@@ -61,7 +61,16 @@ component EntityTest {
     Entity entity = 1;
 }
 
-// TODO: Remove when https://github.com/jamiebrynes7/spatialos-sdk-rs/pull/153 is merged.
+// TODO: Remove the below when https://github.com/jamiebrynes7/spatialos-sdk-rs/pull/153 is merged.
 type Recursive {
     option<Recursive> opt = 1;
+}
+
+enum SomeEnum {
+    FIRST = 0;
+    SECOND = 1;
+}
+
+type MapTypes {
+    map<SomeEnum, int32> first = 1;
 }

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -130,15 +130,18 @@ impl ObjectField for CommandData {
 #[derive(Debug, Clone)]
 pub struct MapTypes {
     pub first: BTreeMap<generated::example::SomeEnum, i32>,
+    pub second: BTreeMap<spatialos_sdk::worker::entity::Entity, i32>,
 }
 impl ObjectField for MapTypes {
     fn from_object(input: &SchemaObject) -> Result<Self> {
         Ok(Self {
             first: input.get::<Map<generated::example::SomeEnum, SchemaInt32>>(1).map_err(Error::at_field::<Self>(1))?,
+            second: input.get::<Map<SchemaEntity, SchemaInt32>>(2).map_err(Error::at_field::<Self>(2))?,
         })
     }
     fn into_object(&self, output: &mut SchemaObject) {
         output.add::<Map<generated::example::SomeEnum, SchemaInt32>>(1, &self.first);
+        output.add::<Map<SchemaEntity, SchemaInt32>>(2, &self.second);
     }
 }
 

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -25,7 +25,50 @@ use std::{collections::BTreeMap, convert::TryFrom};
 use super::super::generated as generated;
 
 /* Enums. */
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum SomeEnum {
+
+    FIRST,
+    SECOND,
+}
+
+impl EnumField for SomeEnum {}
+
+impl Default for SomeEnum {
+    fn default() -> Self {
+        SomeEnum::FIRST
+    }
+}
+
+impl TryFrom<u32> for SomeEnum {
+    type Error = UnknownDiscriminantError;
+
+    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+        match value {
+            
+            0 => Ok(SomeEnum::FIRST), 
+            1 => Ok(SomeEnum::SECOND), 
+            _ => Err(UnknownDiscriminantError {
+                type_name: std::any::type_name::<Self>(),
+                value,
+            }),
+        }
+    }
+}
+
+impl Into<u32> for SomeEnum {
+    fn into(self) -> u32 {
+        match self {
+            
+            SomeEnum::FIRST => 0, 
+            SomeEnum::SECOND => 1, 
+        }
+    }
+}
+
+impl_field_for_enum_field!(SomeEnum);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TestEnum {
 
     FIRST,
@@ -81,6 +124,21 @@ impl ObjectField for CommandData {
     }
     fn into_object(&self, output: &mut SchemaObject) {
         output.add::<SchemaInt32>(1, &self.value);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MapTypes {
+    pub first: BTreeMap<generated::example::SomeEnum, i32>,
+}
+impl ObjectField for MapTypes {
+    fn from_object(input: &SchemaObject) -> Result<Self> {
+        Ok(Self {
+            first: input.get::<Map<generated::example::SomeEnum, SchemaInt32>>(1).map_err(Error::at_field::<Self>(1))?,
+        })
+    }
+    fn into_object(&self, output: &mut SchemaObject) {
+        output.add::<Map<generated::example::SomeEnum, SchemaInt32>>(1, &self.first);
     }
 }
 
@@ -1460,7 +1518,7 @@ use std::{collections::BTreeMap, convert::TryFrom};
 use super::super::super::generated as generated;
 
 /* Enums. */
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Connection_ConnectionStatus {
 
     UNKNOWN,

--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -8,7 +8,7 @@ use <#= vec!["super".to_string(); self.depth() + 1].join("::") #>::generated as 
 let enum_def = self.get_enum_definition(enum_name);
 let enum_rust_name = self.rust_name(&enum_def.qualified_name);
 #>
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum <#= enum_rust_name #> {
 <# for enum_value in &enum_def.values { #>
     <#= enum_value.name #>,<# } #>

--- a/spatialos-sdk/src/worker/entity.rs
+++ b/spatialos-sdk/src/worker/entity.rs
@@ -4,13 +4,13 @@ use crate::worker::{
     schema::*,
 };
 use spatialos_sdk_sys::worker::{Worker_ComponentData, Worker_Entity};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::result::Result;
 use std::slice;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Entity {
-    components: HashMap<ComponentId, Owned<SchemaComponentData>>,
+    components: BTreeMap<ComponentId, Owned<SchemaComponentData>>,
 }
 
 impl Entity {
@@ -104,9 +104,9 @@ impl Entity {
     /// will take ownership of the underlying `Schema_ComponentData` and will free it when
     /// appropriate. If the data is not passed to a similar function in the C SDK, then the data
     /// owned by the `Entity` will leak.
-    pub(crate) fn into_raw(mut self) -> Vec<Worker_ComponentData> {
+    pub(crate) fn into_raw(self) -> Vec<Worker_ComponentData> {
         self.components
-            .drain()
+            .into_iter()
             .map(|(component_id, data)| Worker_ComponentData {
                 component_id,
                 schema_type: data.into_raw(),

--- a/spatialos-sdk/src/worker/schema/owned.rs
+++ b/spatialos-sdk/src/worker/schema/owned.rs
@@ -15,6 +15,7 @@
 //! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
 
 use crate::worker::schema::OwnedPointer;
+use std::cmp::Ordering;
 use std::{
     borrow::Borrow,
     mem,
@@ -90,6 +91,26 @@ impl<T: Ownable> Borrow<T> for Owned<T> {
 impl<T: Ownable> DerefMut for Owned<T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.0.cast().as_ptr() }
+    }
+}
+
+impl<T: Ownable> PartialEq for Owned<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: Ownable> Eq for Owned<T> {}
+
+impl<T: Ownable> PartialOrd for Owned<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<T: Ownable> Ord for Owned<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
     }
 }
 


### PR DESCRIPTION
This PR adds support for both generated enums and entity keys in schema maps.

For enums, just derive the traits required in the generated code.

For schema entities:
- Use `BTreeMap` instead of `HashMap` in the `Entity` type.
- Impl `PartialEq`, `Eq`, `PartialOrd`, `Ord` for `Owned<T>` using the `NonNull` implementations (the ptr address)
- We can now derive the required traits on `Entity`! 

This solves _some_ of the problems described in #153 
