### PR TITLE
Add schema bundles

### DIFF
--- a/spatialos-sdk/Cargo.toml
+++ b/spatialos-sdk/Cargo.toml
@@ -13,6 +13,8 @@ futures = "0.3.1"
 spatialos-sdk-sys = { path = "../spatialos-sdk-sys"}
 
 [dev-dependencies]
+approx = "0.3"
 static_assertions = "1.1.0"
 structopt = "0.3"
 tap="0.4"
+serde_json = "1.0.48"

--- a/spatialos-sdk/resources/bad_bundle
+++ b/spatialos-sdk/resources/bad_bundle
@@ -1,0 +1,124 @@
+
+�	
+.improbable/restricted/system_components.schema
+improbable.restricted"�
+1improbable.restricted.Connection.ConnectionStatus"ConnectionStatus* improbable.restricted.Connection2
+UNKNOWN2$
+
+" improbable.restricted.ConnectionJg
+5
+disconnect"'improbable.restricted.DisconnectRequest*(improbable.restricted.DisconnectResponse02
+O"improbable.restricted.PlayerClient"PlayerClient(=:C
+Qplayer_identity 2(
+&$improbable.restricted.PlayerIdentity
+�
+"improbable/standard_library.schema
+
+improbable*T
+improbable.WorkerAttributeSet"WorkerAttributeSet2
+		attribute B
+*y
+improbable.WorkerRequirementSet"WorkerRequirementSet2:
+
+attribute_set B!
+improbable.WorkerAttributeSet*d
+>improbable.Coordinates"Coordinates2
+?x 2
+
+2
+@y 2
+
+2
+Az 2
+
+*b
+Eimprobable.EdgeLength"
+EdgeLength2
+Fx 2
+
+2
+Gy 2
+
+2
+Hz 2
+
+*s
+gimprobable.ComponentInterest"ComponentInterest2:
+�queries B&
+$"improbable.ComponentInterest.Query*�
+h"improbable.ComponentInterest.Query"Query*improbable.ComponentInterest2F
+i
+constraint 20
+.,improbable.ComponentInterest.QueryConstraint2$
+lfull_snapshot_result :
+2#
+mresult_component_id B
+2
+~	frequency :
+*�
+�,improbable.ComponentInterest.QueryConstraint"QueryConstraint*improbable.ComponentInterest2O
+�sphere_constraint :1
+
+1/improbable.ComponentInterest.CylinderConstraint2I
+�box_constraint :.
+,*improbable.ComponentInterest.BoxConstraint2`
+�relative_sphere_constraint :9
+75improbable.ComponentInterest.RelativeSphereConstraint2d
+�relative_cylinder_constraint :;
+97improbable.ComponentInterest.RelativeCylinderConstraint2Z
+�relative_box_constraint :6
+42improbable.ComponentInterest.RelativeBoxConstraint2%
+�entity_id_constraint :
+2%
+�component_constraint :
+2K
+�and_constraint 	B0
+.,improbable.ComponentInterest.QueryConstraint2J
+�
+or_constraint 
+B0
+.,improbable.ComponentInterest.QueryConstraint*�
+�-improbable.ComponentInterest.SphereConstraint"SphereConstraint*improbable.ComponentInterest2-
+�center 2
+improbable.Coordinates2
+�radius 2
+
+*�
+�/improbable.ComponentInterest.CylinderConstraint"CylinderConstraint*improbable.ComponentInterest2-
+�center 2
+improbable.Coordinates2
+�radius 2
+
+*�
+�*improbable.ComponentInterest.BoxConstraint"
+BoxConstraint*improbable.ComponentInterest2-
+�center 2
+improbable.Coordinates21
+�edge_length 2
+improbable.EdgeLength*�
+�5improbable.ComponentInterest.RelativeSphereConstraint"RelativeSphereConstraint*improbable.ComponentInterest2
+�radius 2
+
+*�
+�7improbable.ComponentInterest.RelativeCylinderConstraint"RelativeCylinderConstraint*improbable.ComponentInterest2
+�radius 2
+
+*�
+�2improbable.ComponentInterest.RelativeBoxConstraint"RelativeBoxConstraint*improbable.ComponentInterest21
+�edge_length 2
+improbable.EdgeLength2�
+!improbable.EntityAcl"	EntityAcl(2:7
+(read_acl 2#
+!improbable.WorkerRequirementSet:F
+.component_write_acl J'
+!improbable.WorkerRequirementSet2D
+3improbable.Metadata"Metadata(5:
+9entity_type 2
+2U
+Qimprobable.Position"Position(6:,
+Scoords 2
+improbable.Coordinates2-
+Yimprobable.Persistence"Persistence(72k
+bimprobable.Interest"Interest(::B
+dcomponent_interest J$
+improbable.ComponentInterest

--- a/spatialos-sdk/resources/good_bundle
+++ b/spatialos-sdk/resources/good_bundle
@@ -1,0 +1,139 @@
+
+»	
+.improbable/restricted/system_components.schema
+improbable.restricted"—
+1improbable.restricted.Connection.ConnectionStatus"ConnectionStatus* improbable.restricted.Connection2
+UNKNOWN2$
+AWAITING_WORKER_CONNECTION 2
+	CONNECTED 2
+DISCONNECTED *√
+ improbable.restricted.Connection"
+Connection2G
+status 25
+31improbable.restricted.Connection.ConnectionStatus2
+'data_latency_ms 2
+2#
+*connected_since_utc 2
+*B
+.'improbable.restricted.DisconnectRequest"DisconnectRequest*D
+0(improbable.restricted.DisconnectResponse"DisconnectResponse*ì
+?$improbable.restricted.PlayerIdentity"PlayerIdentity2!
+Aplayer_identifier 2
+2
+Dprovider 2
+2
+Imetadata 2
+2.
+improbable.restricted.System"System(;2ã
+5improbable.restricted.Worker"Worker(<:
+7	worker_id 2
+:
+8worker_type 2
+::
+9
+connection 2$
+" improbable.restricted.ConnectionJg
+5
+disconnect"'improbable.restricted.DisconnectRequest*(improbable.restricted.DisconnectResponse02
+O"improbable.restricted.PlayerClient"PlayerClient(=:C
+Qplayer_identity 2(
+&$improbable.restricted.PlayerIdentity
+ä
+"improbable/standard_library.schema
+
+improbable*T
+improbable.WorkerAttributeSet"WorkerAttributeSet2
+		attribute B
+*y
+improbable.WorkerRequirementSet"WorkerRequirementSet2:
+attribute_set B!
+improbable.WorkerAttributeSet*d
+>improbable.Coordinates"Coordinates2
+?x 2
+2
+@y 2
+2
+Az 2
+*b
+Eimprobable.EdgeLength"
+EdgeLength2
+Fx 2
+2
+Gy 2
+2
+Hz 2
+*s
+gimprobable.ComponentInterest"ComponentInterest2:
+´queries B&
+$"improbable.ComponentInterest.Query*˝
+h"improbable.ComponentInterest.Query"Query*improbable.ComponentInterest2F
+i
+constraint 20
+.,improbable.ComponentInterest.QueryConstraint2$
+lfull_snapshot_result :
+2#
+mresult_component_id B
+2
+~	frequency :
+*‡
+Å,improbable.ComponentInterest.QueryConstraint"QueryConstraint*improbable.ComponentInterest2O
+Ñsphere_constraint :1
+/-improbable.ComponentInterest.SphereConstraint2S
+Öcylinder_constraint :3
+1/improbable.ComponentInterest.CylinderConstraint2I
+Übox_constraint :.
+,*improbable.ComponentInterest.BoxConstraint2`
+árelative_sphere_constraint :9
+75improbable.ComponentInterest.RelativeSphereConstraint2d
+àrelative_cylinder_constraint :;
+97improbable.ComponentInterest.RelativeCylinderConstraint2Z
+ârelative_box_constraint :6
+42improbable.ComponentInterest.RelativeBoxConstraint2%
+äentity_id_constraint :
+2%
+ãcomponent_constraint :
+2K
+åand_constraint 	B0
+.,improbable.ComponentInterest.QueryConstraint2J
+çor_constraint 
+B0
+.,improbable.ComponentInterest.QueryConstraint*Æ
+ê-improbable.ComponentInterest.SphereConstraint"SphereConstraint*improbable.ComponentInterest2-
+ëcenter 2
+improbable.Coordinates2
+íradius 2
+*≤
+ï/improbable.ComponentInterest.CylinderConstraint"CylinderConstraint*improbable.ComponentInterest2-
+ñcenter 2
+improbable.Coordinates2
+óradius 2
+*¬
+ö*improbable.ComponentInterest.BoxConstraint"BoxConstraint*improbable.ComponentInterest2-
+õcenter 2
+improbable.Coordinates21
+úedge_length 2
+improbable.EdgeLength*è
+ü5improbable.ComponentInterest.RelativeSphereConstraint"RelativeSphereConstraint*improbable.ComponentInterest2
+†radius 2
+*ì
+£7improbable.ComponentInterest.RelativeCylinderConstraint"RelativeCylinderConstraint*improbable.ComponentInterest2
+§radius 2
+*£
+ß2improbable.ComponentInterest.RelativeBoxConstraint"RelativeBoxConstraint*improbable.ComponentInterest21
+®edge_length 2
+improbable.EdgeLength2™
+!improbable.EntityAcl"	EntityAcl(2:7
+(read_acl 2#
+!improbable.WorkerRequirementSet:F
+.component_write_acl J'
+!improbable.WorkerRequirementSet2D
+3improbable.Metadata"Metadata(5:
+9entity_type 2
+2U
+Qimprobable.Position"Position(6:,
+Scoords 2
+improbable.Coordinates2-
+Yimprobable.Persistence"Persistence(72k
+bimprobable.Interest"Interest(::B
+dcomponent_interest J$
+improbable.ComponentInterest

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -70,6 +70,7 @@ use std::{
 #[macro_use]
 mod macros;
 
+mod bundle;
 mod collections;
 mod command_request;
 mod command_response;
@@ -83,7 +84,7 @@ mod ptr;
 pub mod owned;
 
 pub use self::{
-    collections::*, command_request::*, command_response::*, component_data::*,
+    bundle::*, collections::*, command_request::*, command_response::*, component_data::*,
     component_update::*, generic_data::*, object::*, owned::Owned, primitives::*,
 };
 #[doc(inline)]

--- a/spatialos-sdk/src/worker/schema/bundle.rs
+++ b/spatialos-sdk/src/worker/schema/bundle.rs
@@ -1,0 +1,321 @@
+use crate::worker::{component::ComponentId, schema::*, utils::cstr_to_string};
+use spatialos_sdk_sys::worker::*;
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+pub type JsonConversionResult<T> = std::result::Result<(T, Option<String>), String>;
+
+pub struct Bundle {
+    ptr: NonNull<Schema_Bundle>,
+}
+
+impl Bundle {
+    pub fn load(buffer: &[u8]) -> std::result::Result<Self, String> {
+        unsafe {
+            let ptr = Schema_Bundle_Load(buffer.as_ptr(), buffer.len() as u32);
+            let ptr = NonNull::new(ptr)
+                .ok_or_else(|| "Received null pointer from Schema_Bundle_Load".to_string())?;
+            let err = Schema_Bundle_GetError(ptr.as_ptr());
+
+            if !err.is_null() {
+                let msg = cstr_to_string(err);
+                Schema_Bundle_Destroy(ptr.as_ptr());
+                Err(msg)
+            } else {
+                Ok(Bundle { ptr })
+            }
+        }
+    }
+
+    pub fn load_object<T: AsRef<str>, U: AsRef<str>>(
+        &self,
+        qualified_type_name: T,
+        json: U,
+        dest: &mut SchemaObject,
+    ) -> JsonConversionResult<()> {
+        let type_name = CString::new(qualified_type_name.as_ref())
+            .map_err(|_| "Null byte found in 'qualified_type_name'".to_string())?;
+        let json =
+            CString::new(json.as_ref()).map_err(|_| "Null byte found in 'json'".to_string())?;
+
+        unsafe {
+            let success = Schema_Json_LoadObject(
+                self.ptr.as_ptr(),
+                type_name.as_ptr(),
+                json.as_ptr(),
+                dest.as_ptr_mut(),
+            );
+
+            if success == 0 {
+                return Err(Bundle::get_last_error());
+            }
+
+            Ok(((), Bundle::get_last_warning()))
+        }
+    }
+
+    // TODO: Why is this mut?
+    pub fn dump_object<T: AsRef<str>>(
+        &self,
+        qualified_type_name: T,
+        src: &mut SchemaObject,
+    ) -> JsonConversionResult<String> {
+        let type_name = CString::new(qualified_type_name.as_ref())
+            .map_err(|_| "Null byte found in 'qualified_type_name'".to_string())?;
+
+        unsafe {
+            let json_ptr =
+                Schema_Json_DumpObject(self.ptr.as_ptr(), type_name.as_ptr(), src.as_ptr_mut());
+
+            if json_ptr.is_null() {
+                return Err(Bundle::get_last_error());
+            }
+
+            let json = cstr_to_string(Schema_Json_GetJsonString(json_ptr));
+            Schema_Json_Destroy(json_ptr);
+
+            Ok((json, Bundle::get_last_warning()))
+        }
+    }
+
+    pub fn load_component_data<T: AsRef<str>>(
+        &self,
+        component_id: ComponentId,
+        json: T,
+    ) -> JsonConversionResult<Owned<SchemaComponentData>> {
+        let json =
+            CString::new(json.as_ref()).map_err(|_| "Null byte found in 'json'".to_string())?;
+
+        unsafe {
+            self.load_generic(move || {
+                Schema_Json_LoadComponentData(self.ptr.as_ptr(), component_id, json.as_ptr())
+            })
+        }
+    }
+
+    pub fn dump_component_data(
+        &self,
+        component_id: ComponentId,
+        src: &mut SchemaComponentData,
+    ) -> JsonConversionResult<String> {
+        unsafe {
+            self.dump_generic(move || {
+                Schema_Json_DumpComponentData(self.ptr.as_ptr(), component_id, src.as_ptr_mut())
+            })
+        }
+    }
+
+    pub fn load_component_update<T: AsRef<str>>(
+        &self,
+        component_id: ComponentId,
+        json: T,
+    ) -> JsonConversionResult<Owned<SchemaComponentUpdate>> {
+        let json =
+            CString::new(json.as_ref()).map_err(|_| "Null byte found in 'json'".to_string())?;
+
+        unsafe {
+            self.load_generic(move || {
+                Schema_Json_LoadComponentUpdate(self.ptr.as_ptr(), component_id, json.as_ptr())
+            })
+        }
+    }
+
+    pub fn dump_component_update(
+        &self,
+        component_id: ComponentId,
+        src: &mut SchemaComponentUpdate,
+    ) -> JsonConversionResult<String> {
+        unsafe {
+            self.dump_generic(move || {
+                Schema_Json_DumpComponentUpdate(self.ptr.as_ptr(), component_id, src.as_ptr_mut())
+            })
+        }
+    }
+
+    pub fn load_command_request<T: AsRef<str>>(
+        &self,
+        component_id: ComponentId,
+        command_index: u32,
+        json: T,
+    ) -> JsonConversionResult<Owned<SchemaCommandRequest>> {
+        let json =
+            CString::new(json.as_ref()).map_err(|_| "Null byte found in 'json'".to_string())?;
+
+        unsafe {
+            self.load_generic(move || {
+                Schema_Json_LoadCommandRequest(
+                    self.ptr.as_ptr(),
+                    component_id,
+                    command_index,
+                    json.as_ptr(),
+                )
+            })
+        }
+    }
+
+    pub fn dump_command_request(
+        &self,
+        component_id: ComponentId,
+        command_index: u32,
+        src: &mut SchemaCommandRequest,
+    ) -> JsonConversionResult<String> {
+        unsafe {
+            self.dump_generic(move || {
+                Schema_Json_DumpCommandRequest(
+                    self.ptr.as_ptr(),
+                    component_id,
+                    command_index,
+                    src.as_ptr_mut(),
+                )
+            })
+        }
+    }
+
+    pub fn load_command_response<T: AsRef<str>>(
+        &self,
+        component_id: ComponentId,
+        command_index: u32,
+        json: T,
+    ) -> JsonConversionResult<Owned<SchemaCommandResponse>> {
+        let json =
+            CString::new(json.as_ref()).map_err(|_| "Null byte found in 'json'".to_string())?;
+
+        unsafe {
+            self.load_generic(move || {
+                Schema_Json_LoadCommandResponse(
+                    self.ptr.as_ptr(),
+                    component_id,
+                    command_index,
+                    json.as_ptr(),
+                )
+            })
+        }
+    }
+
+    pub fn dump_command_response(
+        &self,
+        component_id: ComponentId,
+        command_index: u32,
+        src: &mut SchemaCommandResponse,
+    ) -> JsonConversionResult<String> {
+        unsafe {
+            self.dump_generic(move || {
+                Schema_Json_DumpCommandResponse(
+                    self.ptr.as_ptr(),
+                    component_id,
+                    command_index,
+                    src.as_ptr_mut(),
+                )
+            })
+        }
+    }
+
+    unsafe fn load_generic<
+        T: OwnedPointer + ToOwned<Owned = Owned<T>>,
+        F: FnOnce() -> *mut T::Raw,
+    >(
+        &self,
+        load: F,
+    ) -> JsonConversionResult<Owned<T>> {
+        let data = load();
+
+        if data.is_null() {
+            return Err(Bundle::get_last_error());
+        }
+
+        let concrete = T::from_raw_mut(data).to_owned();
+        T::DESTROY_FN(data);
+        Ok((concrete, Bundle::get_last_warning()))
+    }
+
+    unsafe fn dump_generic<F: FnOnce() -> *mut Schema_Json>(
+        &self,
+        dump: F,
+    ) -> JsonConversionResult<String> {
+        let json_ptr = dump();
+
+        if json_ptr.is_null() {
+            return Err(Bundle::get_last_error());
+        }
+
+        let json = cstr_to_string(Schema_Json_GetJsonString(json_ptr));
+        Schema_Json_Destroy(json_ptr);
+
+        Ok((json, Bundle::get_last_warning()))
+    }
+
+    unsafe fn get_last_error() -> String {
+        let err = Schema_Json_GetLastError();
+        if err.is_null() {
+            "Unknown error in loading object".to_string()
+        } else {
+            cstr_to_string(err)
+        }
+    }
+
+    unsafe fn get_last_warning() -> Option<String> {
+        let maybe_warning = Schema_Json_GetLastWarning();
+        if maybe_warning.is_null() {
+            None
+        } else {
+            Some(cstr_to_string(maybe_warning))
+        }
+    }
+
+    pub fn convert_data_to_update(
+        &self,
+        component_id: ComponentId,
+        data: Owned<SchemaComponentData>,
+    ) -> std::result::Result<Owned<SchemaComponentUpdate>, String> {
+        let mut error: Option<String> = None;
+        unsafe {
+            let update_ptr = Schema_ConvertComponentDataIntoUpdate(
+                self.ptr.as_ptr(),
+                component_id,
+                data.into_raw(),
+                &mut error as *mut _ as *mut _,
+                Some(Bundle::record_error),
+            );
+
+            if update_ptr.is_null() {
+                return Err(error.unwrap_or_else(|| {
+                    "Unknown error occurred when converting data into update.".to_string()
+                }));
+            }
+
+            let update = SchemaComponentUpdate::from_raw_mut(update_ptr).to_owned();
+            Schema_DestroyComponentUpdate(update_ptr);
+
+            Ok(update)
+        }
+    }
+
+    extern "C" fn record_error(
+        user_data: *mut ::std::os::raw::c_void,
+        error: *const ::std::os::raw::c_char,
+    ) {
+        unsafe {
+            if error.is_null() {
+                return;
+            }
+
+            let data: &mut Option<String> = &mut *(user_data as *mut Option<String>);
+            let error = cstr_to_string(error);
+            *data = Some(error);
+        }
+    }
+}
+
+// SAFETY: It should be safe to send a `Bundle` between threads, so long as it's only ever accessed
+// from one thread at a time. It has unsychronized internal mutability (only storing the 'last' error
+// and warning) so it cannot be Sync.
+unsafe impl Send for Bundle {}
+
+impl Drop for Bundle {
+    fn drop(&mut self) {
+        unsafe {
+            Schema_Bundle_Destroy(self.ptr.as_ptr());
+        }
+    }
+}
+

--- a/spatialos-sdk/src/worker/schema/generic_data.rs
+++ b/spatialos-sdk/src/worker/schema/generic_data.rs
@@ -5,6 +5,10 @@ use std::marker::PhantomData;
 pub struct SchemaGenericData(PhantomData<*mut Schema_GenericData>);
 
 impl SchemaGenericData {
+    pub fn new() -> Owned<Self> {
+        Owned::new()
+    }
+
     pub fn object(&self) -> &SchemaObject {
         unsafe { SchemaObject::from_raw(Schema_GetGenericDataObject(self.as_ptr() as *mut _)) }
     }


### PR DESCRIPTION
The last bit of the 14.1.0 upgrade that I ommitted in #157. This PR adds support for schema bundles. 

There are a number of tests except for the command conversions. I used the schema standard library to generate the binary bundle representations which doesn't have any interesting commands (only empty ones).

In a follow up PR, I'm going to add an option to generate a binary bundle as well as the JSON one in `cargo spatial codegen` and use that to generate more interesting bundles. This is just to keep the PR a bit smaller (its already fairly large).