### PR TITLE
Command traits

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -146,7 +146,7 @@ jobs:
           args: --all-features --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
           SPATIAL_LIB_DIR: "dependencies"
 
       - name: Generate test coverage report

--- a/project-example/src/generated.rs
+++ b/project-example/src/generated.rs
@@ -10,6 +10,7 @@
 
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
+use spatialos_sdk::worker::commands::*;
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::generated as generated;
@@ -22,6 +23,7 @@ use super::generated as generated;
 pub mod example {
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
+use spatialos_sdk::worker::commands::*;
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::super::generated as generated;
@@ -254,63 +256,15 @@ impl Update for EntityIdTestUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum EntityIdTestCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum EntityIdTestCommandResponse {
-}
 
 impl Component for EntityIdTest {
     type Update = EntityIdTestUpdate;
-    type CommandRequest = generated::example::EntityIdTestCommandRequest;
-    type CommandResponse = generated::example::EntityIdTestCommandResponse;
 
     const ID: ComponentId = 2001;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.eid { self.eid = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::EntityIdTestCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::example::EntityIdTestCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::example::EntityIdTestCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::example::EntityIdTestCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::example::EntityIdTestCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::example::EntityIdTestCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -354,63 +308,15 @@ impl Update for EntityTestUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum EntityTestCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum EntityTestCommandResponse {
-}
 
 impl Component for EntityTest {
     type Update = EntityTestUpdate;
-    type CommandRequest = generated::example::EntityTestCommandRequest;
-    type CommandResponse = generated::example::EntityTestCommandResponse;
 
     const ID: ComponentId = 2003;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.entity { self.entity = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::EntityTestCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::example::EntityTestCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::example::EntityTestCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::example::EntityTestCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::example::EntityTestCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::example::EntityTestCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -454,63 +360,15 @@ impl Update for EnumTestComponentUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum EnumTestComponentCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum EnumTestComponentCommandResponse {
-}
 
 impl Component for EnumTestComponent {
     type Update = EnumTestComponentUpdate;
-    type CommandRequest = generated::example::EnumTestComponentCommandRequest;
-    type CommandResponse = generated::example::EnumTestComponentCommandResponse;
 
     const ID: ComponentId = 2002;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.test { self.test = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::EnumTestComponentCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::example::EnumTestComponentCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::example::EnumTestComponentCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::example::EnumTestComponentCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::example::EnumTestComponentCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::example::EnumTestComponentCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -554,9 +412,34 @@ impl Update for ExampleUpdate {
     }
 }
 
+
+
 #[derive(Debug, Clone)]
 pub enum ExampleCommandRequest {
     TestCommand(generated::example::CommandData),
+}
+
+impl Request for ExampleCommandRequest {
+    type Commands = Example;
+
+    fn from_schema(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<Self> {
+        match command_index {
+            1 => {
+                <generated::example::CommandData as ObjectField>::from_object(&request.object())
+                    .map(Self::TestCommand)
+            },
+            _ => Err(Error::unknown_command::<Self>(command_index))
+        }
+    }
+
+    fn into_schema(&self, request: &mut SchemaCommandRequest) -> CommandIndex {
+        match self {
+            Self::TestCommand(ref inner) => {
+                <generated::example::CommandData as ObjectField>::into_object(inner, &mut request.object_mut());
+                1
+            }, 
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -564,71 +447,44 @@ pub enum ExampleCommandResponse {
     TestCommand(generated::example::CommandData),
 }
 
+impl Response for ExampleCommandResponse {
+    type Commands = Example;
+
+    fn from_schema(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<Self> {
+        match command_index { 
+            1 => {
+                <generated::example::CommandData as ObjectField>::from_object(&response.object())
+                    .map(ExampleCommandResponse::TestCommand)
+            }, 
+            _ => Err(Error::unknown_command::<Self>(command_index))
+        }
+    }
+
+    fn into_schema(&self, response: &mut SchemaCommandResponse) -> CommandIndex {
+        match self {
+            Self::TestCommand(ref inner) => {
+                <generated::example::CommandData as ObjectField>::into_object(inner, &mut response.object_mut());
+                1
+            },
+        }
+    }
+}
+
+impl Commands for Example {
+    type Component = Example;
+    type Request = ExampleCommandRequest;
+    type Response = ExampleCommandResponse;
+}
+
+
+
 impl Component for Example {
     type Update = ExampleUpdate;
-    type CommandRequest = generated::example::ExampleCommandRequest;
-    type CommandResponse = generated::example::ExampleCommandResponse;
 
     const ID: ComponentId = 1000;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.x { self.x = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::ExampleCommandRequest> {
-        match command_index {
-            1 => {
-                <generated::example::CommandData as ObjectField>::from_object(&request.object())
-                    .map(ExampleCommandRequest::TestCommand)
-            },
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::example::ExampleCommandResponse> {
-        match command_index {
-            1 => {
-                <generated::example::CommandData as ObjectField>::from_object(&response.object())
-                    .map(ExampleCommandResponse::TestCommand)
-            },
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::example::ExampleCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            ExampleCommandRequest::TestCommand(ref data) => {
-                <generated::example::CommandData as ObjectField>::into_object(data, &mut serialized_request.object_mut());
-            },
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::example::ExampleCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            ExampleCommandResponse::TestCommand(ref data) => {
-                <generated::example::CommandData as ObjectField>::into_object(data, &mut serialized_response.object_mut());
-            },
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::example::ExampleCommandRequest) -> u32 {
-        match request {
-            ExampleCommandRequest::TestCommand(_) => 1,
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::example::ExampleCommandResponse) -> u32 {
-        match response {
-            ExampleCommandResponse::TestCommand(_) => 1,
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -686,18 +542,10 @@ impl Update for RotateUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum RotateCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum RotateCommandResponse {
-}
 
 impl Component for Rotate {
     type Update = RotateUpdate;
-    type CommandRequest = generated::example::RotateCommandRequest;
-    type CommandResponse = generated::example::RotateCommandResponse;
 
     const ID: ComponentId = 1001;
 
@@ -705,46 +553,6 @@ impl Component for Rotate {
         if let Some(value) = update.angle { self.angle = value; }
         if let Some(value) = update.center { self.center = value; }
         if let Some(value) = update.radius { self.radius = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::example::RotateCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::example::RotateCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::example::RotateCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::example::RotateCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::example::RotateCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::example::RotateCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -754,6 +562,7 @@ impl Component for Rotate {
 pub mod improbable {
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
+use spatialos_sdk::worker::commands::*;
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::super::generated as generated;
@@ -1060,64 +869,16 @@ impl Update for EntityAclUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum EntityAclCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum EntityAclCommandResponse {
-}
 
 impl Component for EntityAcl {
     type Update = EntityAclUpdate;
-    type CommandRequest = generated::improbable::EntityAclCommandRequest;
-    type CommandResponse = generated::improbable::EntityAclCommandResponse;
 
     const ID: ComponentId = 50;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.read_acl { self.read_acl = value; }
         if let Some(value) = update.component_write_acl { self.component_write_acl = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::EntityAclCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::EntityAclCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::EntityAclCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::EntityAclCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::EntityAclCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::EntityAclCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -1161,63 +922,15 @@ impl Update for InterestUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum InterestCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum InterestCommandResponse {
-}
 
 impl Component for Interest {
     type Update = InterestUpdate;
-    type CommandRequest = generated::improbable::InterestCommandRequest;
-    type CommandResponse = generated::improbable::InterestCommandResponse;
 
     const ID: ComponentId = 58;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.component_interest { self.component_interest = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::InterestCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::InterestCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::InterestCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::InterestCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::InterestCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::InterestCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -1261,63 +974,15 @@ impl Update for MetadataUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum MetadataCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum MetadataCommandResponse {
-}
 
 impl Component for Metadata {
     type Update = MetadataUpdate;
-    type CommandRequest = generated::improbable::MetadataCommandRequest;
-    type CommandResponse = generated::improbable::MetadataCommandResponse;
 
     const ID: ComponentId = 53;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.entity_type { self.entity_type = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::MetadataCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::MetadataCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::MetadataCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::MetadataCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::MetadataCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::MetadataCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -1354,62 +1019,14 @@ impl Update for PersistenceUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum PersistenceCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum PersistenceCommandResponse {
-}
 
 impl Component for Persistence {
     type Update = PersistenceUpdate;
-    type CommandRequest = generated::improbable::PersistenceCommandRequest;
-    type CommandResponse = generated::improbable::PersistenceCommandResponse;
 
     const ID: ComponentId = 55;
 
     fn merge_update(&mut self, update: Self::Update) {
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::PersistenceCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::PersistenceCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::PersistenceCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::PersistenceCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::PersistenceCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::PersistenceCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -1453,63 +1070,15 @@ impl Update for PositionUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum PositionCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum PositionCommandResponse {
-}
 
 impl Component for Position {
     type Update = PositionUpdate;
-    type CommandRequest = generated::improbable::PositionCommandRequest;
-    type CommandResponse = generated::improbable::PositionCommandResponse;
 
     const ID: ComponentId = 54;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.coords { self.coords = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::PositionCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::PositionCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::PositionCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::PositionCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::PositionCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::PositionCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -1518,6 +1087,7 @@ impl Component for Position {
 pub mod restricted {
 use spatialos_sdk::worker::schema::*;
 use spatialos_sdk::worker::component::*;
+use spatialos_sdk::worker::commands::*;
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use super::super::super::generated as generated;
@@ -1680,63 +1250,15 @@ impl Update for PlayerClientUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum PlayerClientCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum PlayerClientCommandResponse {
-}
 
 impl Component for PlayerClient {
     type Update = PlayerClientUpdate;
-    type CommandRequest = generated::improbable::restricted::PlayerClientCommandRequest;
-    type CommandResponse = generated::improbable::restricted::PlayerClientCommandResponse;
 
     const ID: ComponentId = 61;
 
     fn merge_update(&mut self, update: Self::Update) {
         if let Some(value) = update.player_identity { self.player_identity = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::restricted::PlayerClientCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::restricted::PlayerClientCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::restricted::PlayerClientCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::restricted::PlayerClientCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::restricted::PlayerClientCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::restricted::PlayerClientCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -1773,62 +1295,14 @@ impl Update for SystemUpdate {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum SystemCommandRequest {
-}
 
-#[derive(Debug, Clone)]
-pub enum SystemCommandResponse {
-}
 
 impl Component for System {
     type Update = SystemUpdate;
-    type CommandRequest = generated::improbable::restricted::SystemCommandRequest;
-    type CommandResponse = generated::improbable::restricted::SystemCommandResponse;
 
     const ID: ComponentId = 59;
 
     fn merge_update(&mut self, update: Self::Update) {
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::restricted::SystemCommandRequest> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::restricted::SystemCommandResponse> {
-        match command_index {
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::restricted::SystemCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::restricted::SystemCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::restricted::SystemCommandRequest) -> u32 {
-        match request {
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::restricted::SystemCommandResponse) -> u32 {
-        match response {
-            _ => unreachable!(),
-        }
     }
 }
 
@@ -1886,9 +1360,34 @@ impl Update for WorkerUpdate {
     }
 }
 
+
+
 #[derive(Debug, Clone)]
 pub enum WorkerCommandRequest {
     Disconnect(generated::improbable::restricted::DisconnectRequest),
+}
+
+impl Request for WorkerCommandRequest {
+    type Commands = Worker;
+
+    fn from_schema(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<Self> {
+        match command_index {
+            1 => {
+                <generated::improbable::restricted::DisconnectRequest as ObjectField>::from_object(&request.object())
+                    .map(Self::Disconnect)
+            },
+            _ => Err(Error::unknown_command::<Self>(command_index))
+        }
+    }
+
+    fn into_schema(&self, request: &mut SchemaCommandRequest) -> CommandIndex {
+        match self {
+            Self::Disconnect(ref inner) => {
+                <generated::improbable::restricted::DisconnectRequest as ObjectField>::into_object(inner, &mut request.object_mut());
+                1
+            }, 
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1896,10 +1395,39 @@ pub enum WorkerCommandResponse {
     Disconnect(generated::improbable::restricted::DisconnectResponse),
 }
 
+impl Response for WorkerCommandResponse {
+    type Commands = Worker;
+
+    fn from_schema(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<Self> {
+        match command_index { 
+            1 => {
+                <generated::improbable::restricted::DisconnectResponse as ObjectField>::from_object(&response.object())
+                    .map(WorkerCommandResponse::Disconnect)
+            }, 
+            _ => Err(Error::unknown_command::<Self>(command_index))
+        }
+    }
+
+    fn into_schema(&self, response: &mut SchemaCommandResponse) -> CommandIndex {
+        match self {
+            Self::Disconnect(ref inner) => {
+                <generated::improbable::restricted::DisconnectResponse as ObjectField>::into_object(inner, &mut response.object_mut());
+                1
+            },
+        }
+    }
+}
+
+impl Commands for Worker {
+    type Component = Worker;
+    type Request = WorkerCommandRequest;
+    type Response = WorkerCommandResponse;
+}
+
+
+
 impl Component for Worker {
     type Update = WorkerUpdate;
-    type CommandRequest = generated::improbable::restricted::WorkerCommandRequest;
-    type CommandResponse = generated::improbable::restricted::WorkerCommandResponse;
 
     const ID: ComponentId = 60;
 
@@ -1907,62 +1435,6 @@ impl Component for Worker {
         if let Some(value) = update.worker_id { self.worker_id = value; }
         if let Some(value) = update.worker_type { self.worker_type = value; }
         if let Some(value) = update.connection { self.connection = value; }
-    }
-
-    fn from_request(command_index: CommandIndex, request: &SchemaCommandRequest) -> Result<generated::improbable::restricted::WorkerCommandRequest> {
-        match command_index {
-            1 => {
-                <generated::improbable::restricted::DisconnectRequest as ObjectField>::from_object(&request.object())
-                    .map(WorkerCommandRequest::Disconnect)
-            },
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn from_response(command_index: CommandIndex, response: &SchemaCommandResponse) -> Result<generated::improbable::restricted::WorkerCommandResponse> {
-        match command_index {
-            1 => {
-                <generated::improbable::restricted::DisconnectResponse as ObjectField>::from_object(&response.object())
-                    .map(WorkerCommandResponse::Disconnect)
-            },
-            _ => Err(Error::unknown_command::<Self>(command_index))
-        }
-    }
-
-    fn to_request(request: &generated::improbable::restricted::WorkerCommandRequest) -> Owned<SchemaCommandRequest> {
-        let mut serialized_request = SchemaCommandRequest::new();
-        match request {
-            WorkerCommandRequest::Disconnect(ref data) => {
-                <generated::improbable::restricted::DisconnectRequest as ObjectField>::into_object(data, &mut serialized_request.object_mut());
-            },
-            _ => unreachable!()
-        }
-        serialized_request
-    }
-
-    fn to_response(response: &generated::improbable::restricted::WorkerCommandResponse) -> Owned<SchemaCommandResponse> {
-        let mut serialized_response = SchemaCommandResponse::new();
-        match response {
-            WorkerCommandResponse::Disconnect(ref data) => {
-                <generated::improbable::restricted::DisconnectResponse as ObjectField>::into_object(data, &mut serialized_response.object_mut());
-            },
-            _ => unreachable!()
-        }
-        serialized_response
-    }
-
-    fn get_request_command_index(request: &generated::improbable::restricted::WorkerCommandRequest) -> u32 {
-        match request {
-            WorkerCommandRequest::Disconnect(_) => 1,
-            _ => unreachable!(),
-        }
-    }
-
-    fn get_response_command_index(response: &generated::improbable::restricted::WorkerCommandResponse) -> u32 {
-        match response {
-            WorkerCommandResponse::Disconnect(_) => 1,
-            _ => unreachable!(),
-        }
     }
 }
 

--- a/project-example/src/main.rs
+++ b/project-example/src/main.rs
@@ -7,6 +7,7 @@ use crate::{connection_handler::*, opt::*};
 use futures::executor::block_on;
 use generated::{example, improbable};
 use rand::Rng;
+use spatialos_sdk::worker::commands::CreateEntityRequest;
 use spatialos_sdk::worker::{
     commands::{EntityQueryRequest, ReserveEntityIdsRequest},
     component::{Component, UpdateParameters},
@@ -84,7 +85,7 @@ fn logic_loop(c: &mut WorkerConnection) {
 
     let entity = builder.build().unwrap();
 
-    let create_request_id = c.send_create_entity_request(entity, None, None);
+    let create_request_id = c.send_create_entity_request(CreateEntityRequest(entity, None), None);
     println!("Create entity request ID: {:?}", create_request_id);
 
     loop {

--- a/spatialos-sdk/src/worker/commands.rs
+++ b/spatialos-sdk/src/worker/commands.rs
@@ -1,3 +1,4 @@
+use crate::worker::entity::Entity;
 use crate::worker::query::EntityQuery;
 use crate::worker::EntityId;
 use spatialos_sdk_sys::worker::Worker_CommandParameters;
@@ -53,18 +54,12 @@ impl CommandParameters {
     }
 }
 
-#[derive(Debug)]
-pub struct IncomingCommandRequest {}
-
-#[derive(Debug)]
-pub struct OutgoingCommandRequest {}
-
 // =============================== World Commands =============================== //
 #[derive(Debug)]
 pub struct ReserveEntityIdsRequest(pub u32);
 
 #[derive(Debug)]
-pub struct CreateEntityRequest {}
+pub struct CreateEntityRequest(pub Entity, pub Option<EntityId>);
 
 #[derive(Debug)]
 pub struct DeleteEntityRequest(pub EntityId);

--- a/spatialos-sdk/src/worker/commands.rs
+++ b/spatialos-sdk/src/worker/commands.rs
@@ -84,10 +84,6 @@ impl<'a> CommandRequestRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the request impl `ObjectField`
-    // here, but in practice this will always be true for all component types. Future
-    // iterations should clean this up such that the `Component` trait can imply these
-    // other bounds automatically (i.e. by making them super traits of `Component`).
     pub(crate) fn get<C: Commands>(&self) -> Option<schema::Result<C::Request>> {
         if C::Component::ID != self.component_id {
             return None;
@@ -116,10 +112,6 @@ impl<'a> CommandResponseRef<'a> {
         }
     }
 
-    // NOTE: We manually declare that the response impl `ObjectField`
-    // here, but in practice this will always be true for all component types. Future
-    // iterations should clean this up such that the `Component` trait can imply these
-    // other bounds automatically (i.e. by making them super traits of `Component`).
     pub fn get<C: Commands>(&self) -> Option<schema::Result<C::Response>> {
         if C::Component::ID != self.component_id {
             return None;

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -1,8 +1,7 @@
 use crate::ptr::MutPtr;
-use crate::worker::component::ComponentUpdate;
 use crate::worker::{
     commands::*,
-    component::{Component, UpdateParameters},
+    component::*,
     locator::*,
     metrics::Metrics,
     op::OpList,
@@ -163,18 +162,18 @@ pub trait Connection {
         timeout_millis: Option<u32>,
     ) -> RequestId;
 
-    fn send_command_request<C: Component>(
+    fn send_command_request<T: Into<CommandRequest>>(
         &mut self,
         entity_id: EntityId,
-        request: &C::CommandRequest,
+        request: T,
         timeout_millis: Option<u32>,
         params: CommandParameters,
     ) -> RequestId;
 
-    fn send_command_response<C: Component>(
+    fn send_command_response<T: Into<CommandResponse>>(
         &mut self,
         request_id: RequestId,
-        response: &C::CommandResponse,
+        response: T,
     );
 
     fn send_command_failure(
@@ -401,25 +400,25 @@ impl Connection for WorkerConnection {
         }
     }
 
-    fn send_command_request<C: Component>(
+    fn send_command_request<T: Into<CommandRequest>>(
         &mut self,
         entity_id: EntityId,
-        request: &C::CommandRequest,
+        request: T,
         timeout_millis: Option<u32>,
         params: CommandParameters,
     ) -> RequestId {
-        let command_index = C::get_request_command_index(&request);
-
         let timeout = match timeout_millis {
             Some(c) => &c,
             None => ptr::null(),
         };
 
+        let command = request.into();
+
         let mut command_request = Worker_CommandRequest {
             reserved: ptr::null_mut(),
-            component_id: C::ID,
-            command_index,
-            schema_type: C::to_request(&request).into_raw(),
+            component_id: command.component_id,
+            command_index: command.command_index,
+            schema_type: command.schema_data.into_raw(),
             user_handle: ptr::null_mut(),
         };
 
@@ -434,16 +433,18 @@ impl Connection for WorkerConnection {
         }
     }
 
-    fn send_command_response<C: Component>(
+    fn send_command_response<T: Into<CommandResponse>>(
         &mut self,
         request_id: RequestId,
-        response: &C::CommandResponse,
+        response: T,
     ) {
+        let command = response.into();
+
         let mut raw_response = Worker_CommandResponse {
             reserved: ptr::null_mut(),
-            component_id: C::ID,
-            command_index: C::get_response_command_index(response),
-            schema_type: C::to_response(response).into_raw(),
+            component_id: command.component_id,
+            command_index: command.command_index,
+            schema_type: command.schema_data.into_raw(),
             user_handle: ptr::null_mut(),
         };
 

--- a/spatialos-sdk/src/worker/connection.rs
+++ b/spatialos-sdk/src/worker/connection.rs
@@ -3,7 +3,6 @@ use crate::worker::component::ComponentUpdate;
 use crate::worker::{
     commands::*,
     component::{Component, UpdateParameters},
-    entity::Entity,
     locator::*,
     metrics::Metrics,
     op::OpList,
@@ -150,8 +149,7 @@ pub trait Connection {
     ) -> RequestId;
     fn send_create_entity_request(
         &mut self,
-        entity: Entity,
-        entity_id: Option<EntityId>,
+        payload: CreateEntityRequest,
         timeout_millis: Option<u32>,
     ) -> RequestId;
     fn send_delete_entity_request(
@@ -342,19 +340,18 @@ impl Connection for WorkerConnection {
 
     fn send_create_entity_request(
         &mut self,
-        entity: Entity,
-        entity_id: Option<EntityId>,
+        payload: CreateEntityRequest,
         timeout_millis: Option<u32>,
     ) -> RequestId {
         let timeout = match timeout_millis {
             Some(c) => &c,
             None => ptr::null(),
         };
-        let entity_id = match entity_id {
+        let entity_id = match payload.1 {
             Some(e) => &e.id,
             None => ptr::null(),
         };
-        let mut component_data = entity.into_raw();
+        let mut component_data = payload.0.into_raw();
         unsafe {
             RequestId::new(Worker_Connection_SendCreateEntityRequest(
                 self.connection_ptr.get(),

--- a/spatialos-sdk/src/worker/schema.rs
+++ b/spatialos-sdk/src/worker/schema.rs
@@ -58,7 +58,7 @@
 //! }
 //! ```
 
-use crate::worker::component::CommandIndex;
+use crate::worker::commands::CommandIndex;
 use std::{
     convert::TryFrom,
     fmt::{self, Display, Formatter},


### PR DESCRIPTION
Following on from @randomPoison's ideas in #121 and examples in various previous PRs, this PR splits out  the `CommandResponse` and `CommandRequest` traits from the `Component` trait. 

It also restructures the traits somewhat such that there is a `Commands` trait which is only implemented if there any commands associated with that component. This cuts down on unnecessary generated code and models the domain (schema) a bit more accurately.

There are a number of associated changes in this PR:

- Refactored `StatusCode` in command response ops to just be a plain old `Result<T, E>`.
- Removed some unused types/methods
- Moved command related things into the `commands.rs` file 