### PR TITLE
[WIP] downloading dependencies at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 # SpatialOS SDK dependencies.
 dependencies/
 .idea/workspace.xml
+/spatialos-sdk-sys/dependecies/

--- a/cargo-spatial/Cargo.toml
+++ b/cargo-spatial/Cargo.toml
@@ -19,3 +19,8 @@ spatialos-sdk-code-generator = { path = "../spatialos-sdk-code-generator" }
 structopt = "0.3"
 tempfile = "3.0"
 toml = "0.5"
+
+
+[lib]
+name = "cargo_spatial"
+path = "src/lib.rs"

--- a/cargo-spatial/src/download.rs
+++ b/cargo-spatial/src/download.rs
@@ -200,14 +200,15 @@ pub fn download_sdk(
         })?;
 
     info!("Downloading packages into: {}", spatial_lib_dir);
+    download_sdk_version(spatial_lib_dir, spatial_sdk_version, options.with_test_schema)
+}
+
+
+pub fn download_sdk_version(spatial_lib_dir:String, spatial_sdk_version: String, with_test_schema: bool)-> Result<(), Error<ErrorKind>>{
 
     // Clean existing directory.
     if Path::new(&spatial_lib_dir).exists() {
-        fs::remove_dir_all(&spatial_lib_dir).map_err(|e| Error {
-            kind: ErrorKind::IO,
-            msg: format!("Failed to remove directory {}.", &spatial_lib_dir),
-            inner: Some(Box::new(e)),
-        })?;
+       return Ok(());
     }
 
     fs::create_dir_all(&spatial_lib_dir).map_err(|e| Error {
@@ -225,7 +226,7 @@ pub fn download_sdk(
         download_package(*package, &spatial_sdk_version, &spatial_lib_dir)?;
     }
 
-    if options.with_test_schema {
+    if with_test_schema {
         download_package(
             SpatialPackageSource::Schema(SpatialSchemaPackage::ExhaustiveTestSchema),
             &spatial_sdk_version,

--- a/spatialos-sdk-sys/Cargo.toml
+++ b/spatialos-sdk-sys/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2018"
 links = "worker"
 build = "build.rs"
 
-[dependencies]
+[build-dependencies]
+cargo-spatial = {path = "../cargo-spatial"}

--- a/spatialos-sdk-sys/build.rs
+++ b/spatialos-sdk-sys/build.rs
@@ -1,4 +1,5 @@
-use std::env;
+extern crate cargo_spatial;
+
 use std::path::Path;
 
 #[cfg(windows)]
@@ -14,12 +15,12 @@ static PACKAGE_DIR: &str = "macos";
 static PACKAGE_DIR: &str = "win";
 
 fn main() {
-    let lib_dir = match env::var("SPATIAL_LIB_DIR") {
-        Ok(s) => s,
-        Err(_) => panic!("SPATIAL_LIB_DIR environment variable not set."),
-    };
 
-    let package_dir = Path::new(&lib_dir).join(PACKAGE_DIR);
+    cargo_spatial::download::download_sdk_version("./dependecies/".to_string(), "14.1.0".to_string(), false).ok();
+    let lib_dir  = "./dependecies";
+
+    let package_dir = Path::new(&lib_dir).join(PACKAGE_DIR).canonicalize().ok().unwrap();
+    
 
     println!("cargo:rustc-link-search={}", package_dir.to_str().unwrap());
 


### PR DESCRIPTION
Requiring the environment variable "SPATIAL_LIBS_DIR" has been causing me a bunch of issues (cargo check can't be run by IDEs for example).

This change has helped me with my setup significantly - it downloads the dependencies when spatial-os-sdk is built, and links to them in that directory. It also doens't redownload every time which significantly helps compile times. 

Not comprehensive, but wanted to see what you thought of doing it this way. 