### PR TITLE
Download `spatialos-sdk-sys` packages at runtime

### DIFF
--- a/.idea/spatialos-sdk-rs.iml
+++ b/.idea/spatialos-sdk-rs.iml
@@ -3,41 +3,42 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-sys/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-sys\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-sys\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-sys\benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-sys/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-sys/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-sys/benches" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/cargo-spatial/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/cargo-spatial\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/cargo-spatial\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/cargo-spatial\benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/cargo-spatial/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/cargo-spatial/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/cargo-spatial/benches" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator\benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator/benches" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-tools/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-tools\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-tools\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-tools\benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-tools/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-tools/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk-tools/benches" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk/examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk\benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spatialos-sdk/benches" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/test-suite/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test-suite\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test-suite\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/test-suite\benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test-suite/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test-suite/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test-suite/benches" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/project-example/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/project-example\examples" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/project-example\tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/project-example\benches" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/cargo-spatial\target" />
-      <excludeFolder url="file://$MODULE_DIR$/project-example\target" />
-      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator\target" />
-      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk-sys\target" />
-      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk-tools\target" />
-      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk\target" />
-      <excludeFolder url="file://$MODULE_DIR$/test-suite\target" />
-      <excludeFolder url="file://$MODULE_DIR$/../spatialos-sdk-rs\target" />
+      <sourceFolder url="file://$MODULE_DIR$/project-example/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/project-example/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/project-example/benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/cargo-spatial-package-downloader/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/cargo-spatial/target" />
+      <excludeFolder url="file://$MODULE_DIR$/project-example/target" />
+      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk-code-generator/target" />
+      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk-sys/target" />
+      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk-tools/target" />
+      <excludeFolder url="file://$MODULE_DIR$/spatialos-sdk/target" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+      <excludeFolder url="file://$MODULE_DIR$/test-suite/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "cargo-spatial",
+    "cargo-spatial-package-downloader",
     "project-example",
     "spatialos-sdk",
     "spatialos-sdk-code-generator",

--- a/cargo-spatial-package-downloader/Cargo.toml
+++ b/cargo-spatial-package-downloader/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cargo-spatial-package-downloader"
+version = "0.1.0"
+authors = ["Jamie Brynes <jamiebrynes7@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4.1"

--- a/cargo-spatial-package-downloader/src/lib.rs
+++ b/cargo-spatial-package-downloader/src/lib.rs
@@ -1,0 +1,187 @@
+use log::*;
+use std::fmt::{Debug, Display, Formatter};
+use std::path::PathBuf;
+use std::process;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpatialWorkerSdkPackage {
+    CHeaders,
+    CApiWin,
+    CApiMac,
+    CApiLinux,
+}
+
+impl SpatialWorkerSdkPackage {
+    fn package_name(self) -> &'static str {
+        match self {
+            SpatialWorkerSdkPackage::CHeaders => "c_headers",
+            SpatialWorkerSdkPackage::CApiWin => "c-static-x86_64-vc140_mt-win32",
+            SpatialWorkerSdkPackage::CApiMac => "c-static-x86_64-clang-macos",
+            SpatialWorkerSdkPackage::CApiLinux => "c-static-x86_64-gcc510_pic-linux",
+        }
+    }
+
+    fn relative_target_directory(self) -> &'static str {
+        match self {
+            SpatialWorkerSdkPackage::CHeaders => "headers",
+            SpatialWorkerSdkPackage::CApiWin => "win",
+            SpatialWorkerSdkPackage::CApiMac => "macos",
+            SpatialWorkerSdkPackage::CApiLinux => "linux",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpatialToolsPackage {
+    SchemaCompilerWin,
+    SchemaCompilerMac,
+    SchemaCompilerLinux,
+    SnapshotConverterWin,
+    SnapshotConverterMac,
+    SnapshotConverterLinux,
+}
+
+impl SpatialToolsPackage {
+    fn package_name(self) -> &'static str {
+        match self {
+            SpatialToolsPackage::SchemaCompilerWin => "schema_compiler-x86_64-win32",
+            SpatialToolsPackage::SchemaCompilerMac => "schema_compiler-x86_64-macos",
+            SpatialToolsPackage::SchemaCompilerLinux => "schema_compiler-x86_64-linux",
+            SpatialToolsPackage::SnapshotConverterWin => "snapshot_converter-x86_64-win32",
+            SpatialToolsPackage::SnapshotConverterMac => "snapshot_converter-x86_64-macos",
+            SpatialToolsPackage::SnapshotConverterLinux => "snapshot_converter-x86_64-linux",
+        }
+    }
+
+    fn relative_target_directory(self) -> &'static str {
+        match self {
+            SpatialToolsPackage::SchemaCompilerWin
+            | SpatialToolsPackage::SchemaCompilerMac
+            | SpatialToolsPackage::SchemaCompilerLinux => "schema-compiler",
+            SpatialToolsPackage::SnapshotConverterWin
+            | SpatialToolsPackage::SnapshotConverterMac
+            | SpatialToolsPackage::SnapshotConverterLinux => "snapshot-converter",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpatialSchemaPackage {
+    StandardLibrary,
+    ExhaustiveTestSchema,
+}
+
+impl SpatialSchemaPackage {
+    fn package_name(self) -> &'static str {
+        match self {
+            SpatialSchemaPackage::StandardLibrary => "standard_library",
+            SpatialSchemaPackage::ExhaustiveTestSchema => "test_schema_library",
+        }
+    }
+
+    fn relative_target_directory(self) -> &'static str {
+        match self {
+            SpatialSchemaPackage::StandardLibrary => "std-lib",
+            SpatialSchemaPackage::ExhaustiveTestSchema => "test-schema",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpatialPackageSource {
+    WorkerSdk(SpatialWorkerSdkPackage),
+    Tools(SpatialToolsPackage),
+    Schema(SpatialSchemaPackage),
+}
+
+impl SpatialPackageSource {
+    fn package_name(self) -> Vec<&'static str> {
+        match self {
+            SpatialPackageSource::WorkerSdk(package) => vec!["worker_sdk", package.package_name()],
+            SpatialPackageSource::Tools(package) => vec!["tools", package.package_name()],
+            SpatialPackageSource::Schema(package) => vec!["schema", package.package_name()],
+        }
+    }
+
+    fn relative_target_directory(self) -> &'static str {
+        match self {
+            SpatialPackageSource::WorkerSdk(package) => package.relative_target_directory(),
+            SpatialPackageSource::Tools(package) => package.relative_target_directory(),
+            SpatialPackageSource::Schema(package) => package.relative_target_directory(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    pub msg: String,
+    pub inner: Option<Box<dyn std::error::Error>>,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let mut msg = self.msg.clone();
+
+        if let Some(ref inner) = self.inner {
+            msg = format!("{}\nInner error: {}", msg, inner);
+        }
+
+        f.write_str(&msg)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.as_ref().map(|e| e.as_ref())
+    }
+}
+
+pub fn download_package(
+    package_source: SpatialPackageSource,
+    sdk_version: &str,
+    spatial_lib_dir: &str,
+) -> Result<(), Error> {
+    info!("Downloading {}", package_source.package_name().join(" "));
+
+    let mut output_path = PathBuf::new();
+    output_path.push(spatial_lib_dir);
+    output_path.push(package_source.relative_target_directory());
+
+    let mut args = vec!["package", "retrieve"];
+
+    args.extend(package_source.package_name());
+    args.push(sdk_version);
+    args.push(output_path.to_str().unwrap());
+    args.push("--unzip");
+
+    trace!("Running spatial command with arguments: {:?}", args);
+
+    let process = process::Command::new("spatial")
+        .args(args)
+        .output()
+        .map_err(|e| Error {
+            msg: "Failed to run 'spatial'.".into(),
+            inner: Some(Box::new(e)),
+        })?;
+
+    if !process.status.success() {
+        if let Ok(stdout) = String::from_utf8(process.stdout) {
+            trace!("{}", stdout);
+        } else {
+            warn!("Could not read 'spatial' standard out.");
+        }
+
+        return Err(match String::from_utf8(process.stderr) {
+            Ok(err) => Error {
+                msg: err,
+                inner: None,
+            },
+            Err(e) => Error {
+                msg: "Package download failed and stderr is not utf-8 compliant.".into(),
+                inner: Some(Box::new(e)),
+            },
+        });
+    }
+
+    Ok(())
+}

--- a/cargo-spatial/Cargo.toml
+++ b/cargo-spatial/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 edition = "2018"
 
 [dependencies]
+cargo-spatial-package-downloader = { path = "../cargo-spatial-package-downloader" }
 log = "0.4.1"
 rand = "0.7"
 reqwest = { version = "0.10.0", features = ["blocking"] }

--- a/cargo-spatial/src/download.rs
+++ b/cargo-spatial/src/download.rs
@@ -7,6 +7,10 @@ pub use self::macos::*;
 pub use self::windows::*;
 
 use crate::{config::Config, errors::Error, opt::DownloadSdk};
+use cargo_spatial_package_downloader::{
+    download_package, SpatialPackageSource, SpatialSchemaPackage, SpatialToolsPackage,
+    SpatialWorkerSdkPackage,
+};
 use log::*;
 use std::{
     fmt::{Display, Formatter},
@@ -14,117 +18,7 @@ use std::{
     fs::File,
     io::copy,
     path::{Path, PathBuf},
-    process,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum SpatialWorkerSdkPackage {
-    CHeaders,
-    CApiWin,
-    CApiMac,
-    CApiLinux,
-}
-
-impl SpatialWorkerSdkPackage {
-    fn package_name(self) -> &'static str {
-        match self {
-            SpatialWorkerSdkPackage::CHeaders => "c_headers",
-            SpatialWorkerSdkPackage::CApiWin => "c-static-x86_64-vc140_mt-win32",
-            SpatialWorkerSdkPackage::CApiMac => "c-static-x86_64-clang-macos",
-            SpatialWorkerSdkPackage::CApiLinux => "c-static-x86_64-gcc510_pic-linux",
-        }
-    }
-
-    fn relative_target_directory(self) -> &'static str {
-        match self {
-            SpatialWorkerSdkPackage::CHeaders => "headers",
-            SpatialWorkerSdkPackage::CApiWin => "win",
-            SpatialWorkerSdkPackage::CApiMac => "macos",
-            SpatialWorkerSdkPackage::CApiLinux => "linux",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum SpatialToolsPackage {
-    SchemaCompilerWin,
-    SchemaCompilerMac,
-    SchemaCompilerLinux,
-    SnapshotConverterWin,
-    SnapshotConverterMac,
-    SnapshotConverterLinux,
-}
-
-impl SpatialToolsPackage {
-    fn package_name(self) -> &'static str {
-        match self {
-            SpatialToolsPackage::SchemaCompilerWin => "schema_compiler-x86_64-win32",
-            SpatialToolsPackage::SchemaCompilerMac => "schema_compiler-x86_64-macos",
-            SpatialToolsPackage::SchemaCompilerLinux => "schema_compiler-x86_64-linux",
-            SpatialToolsPackage::SnapshotConverterWin => "snapshot_converter-x86_64-win32",
-            SpatialToolsPackage::SnapshotConverterMac => "snapshot_converter-x86_64-macos",
-            SpatialToolsPackage::SnapshotConverterLinux => "snapshot_converter-x86_64-linux",
-        }
-    }
-
-    fn relative_target_directory(self) -> &'static str {
-        match self {
-            SpatialToolsPackage::SchemaCompilerWin
-            | SpatialToolsPackage::SchemaCompilerMac
-            | SpatialToolsPackage::SchemaCompilerLinux => "schema-compiler",
-            SpatialToolsPackage::SnapshotConverterWin
-            | SpatialToolsPackage::SnapshotConverterMac
-            | SpatialToolsPackage::SnapshotConverterLinux => "snapshot-converter",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum SpatialSchemaPackage {
-    StandardLibrary,
-    ExhaustiveTestSchema,
-}
-
-impl SpatialSchemaPackage {
-    fn package_name(self) -> &'static str {
-        match self {
-            SpatialSchemaPackage::StandardLibrary => "standard_library",
-            SpatialSchemaPackage::ExhaustiveTestSchema => "test_schema_library",
-        }
-    }
-
-    fn relative_target_directory(self) -> &'static str {
-        match self {
-            SpatialSchemaPackage::StandardLibrary => "std-lib",
-            SpatialSchemaPackage::ExhaustiveTestSchema => "test-schema",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum SpatialPackageSource {
-    WorkerSdk(SpatialWorkerSdkPackage),
-    Tools(SpatialToolsPackage),
-    Schema(SpatialSchemaPackage),
-}
-
-impl SpatialPackageSource {
-    fn package_name(self) -> Vec<&'static str> {
-        match self {
-            SpatialPackageSource::WorkerSdk(package) => vec!["worker_sdk", package.package_name()],
-            SpatialPackageSource::Tools(package) => vec!["tools", package.package_name()],
-            SpatialPackageSource::Schema(package) => vec!["schema", package.package_name()],
-        }
-    }
-
-    fn relative_target_directory(self) -> &'static str {
-        match self {
-            SpatialPackageSource::WorkerSdk(package) => package.relative_target_directory(),
-            SpatialPackageSource::Tools(package) => package.relative_target_directory(),
-            SpatialPackageSource::Schema(package) => package.relative_target_directory(),
-        }
-    }
-}
 
 // TODO: Allow users to specify which ones of these want? Linux is always required.
 static COMMON_PACKAGES: &[SpatialPackageSource] = &[
@@ -218,11 +112,19 @@ pub fn download_sdk(
     trace!("Spatial lib directory cleaned.");
 
     for package in COMMON_PACKAGES {
-        download_package(*package, &spatial_sdk_version, &spatial_lib_dir)?;
+        download_package(*package, &spatial_sdk_version, &spatial_lib_dir).map_err(|e| Error {
+            kind: ErrorKind::FailedDownload,
+            msg: "Failed to download package".to_owned(),
+            inner: Some(Box::new(e)),
+        })?;
     }
 
     for package in PLATFORM_PACKAGES {
-        download_package(*package, &spatial_sdk_version, &spatial_lib_dir)?;
+        download_package(*package, &spatial_sdk_version, &spatial_lib_dir).map_err(|e| Error {
+            kind: ErrorKind::FailedDownload,
+            msg: "Failed to download package".to_owned(),
+            inner: Some(Box::new(e)),
+        })?;
     }
 
     if options.with_test_schema {
@@ -230,60 +132,12 @@ pub fn download_sdk(
             SpatialPackageSource::Schema(SpatialSchemaPackage::ExhaustiveTestSchema),
             &spatial_sdk_version,
             &spatial_lib_dir,
-        )?;
-    }
-
-    Ok(())
-}
-
-fn download_package(
-    package_source: SpatialPackageSource,
-    sdk_version: &str,
-    spatial_lib_dir: &str,
-) -> Result<(), Error<ErrorKind>> {
-    info!("Downloading {}", package_source.package_name().join(" "));
-
-    let mut output_path = PathBuf::new();
-    output_path.push(spatial_lib_dir);
-    output_path.push(package_source.relative_target_directory());
-
-    let mut args = vec!["package", "retrieve"];
-
-    args.extend(package_source.package_name());
-    args.push(sdk_version);
-    args.push(output_path.to_str().unwrap());
-    args.push("--unzip");
-
-    trace!("Running spatial command with arguments: {:?}", args);
-
-    let process = process::Command::new("spatial")
-        .args(args)
-        .output()
+        )
         .map_err(|e| Error {
             kind: ErrorKind::FailedDownload,
-            msg: "Failed to run 'spatial'.".into(),
+            msg: "Failed to download package".to_owned(),
             inner: Some(Box::new(e)),
         })?;
-
-    if !process.status.success() {
-        if let Ok(stdout) = String::from_utf8(process.stdout) {
-            trace!("{}", stdout);
-        } else {
-            warn!("Could not read 'spatial' standard out.");
-        }
-
-        return Err(match String::from_utf8(process.stderr) {
-            Ok(err) => Error {
-                kind: ErrorKind::FailedDownload,
-                msg: err,
-                inner: None,
-            },
-            Err(e) => Error {
-                kind: ErrorKind::FailedDownload,
-                msg: "Package download failed and stderr is not utf-8 compliant.".into(),
-                inner: Some(Box::new(e)),
-            },
-        });
     }
 
     Ok(())

--- a/spatialos-sdk-sys/Cargo.toml
+++ b/spatialos-sdk-sys/Cargo.toml
@@ -10,3 +10,6 @@ links = "worker"
 build = "build.rs"
 
 [dependencies]
+
+[build-dependencies]
+cargo-spatial-package-downloader = { path = "../cargo-spatial-package-downloader" }

--- a/spatialos-sdk-sys/build.rs
+++ b/spatialos-sdk-sys/build.rs
@@ -1,5 +1,9 @@
+use cargo_spatial_package_downloader::{
+    download_package, SpatialPackageSource, SpatialWorkerSdkPackage,
+};
 use std::env;
-use std::path::Path;
+use std::error::Error;
+use std::path::{Path, PathBuf};
 
 #[cfg(windows)]
 const LIBS: [&str; 4] = ["improbable_worker", "RakNetLibStatic", "ssl", "zlibstatic"];
@@ -13,16 +17,32 @@ static PACKAGE_DIR: &str = "macos";
 #[cfg(target_os = "windows")]
 static PACKAGE_DIR: &str = "win";
 
-fn main() {
+#[cfg(target_os = "linux")]
+static PACKAGE: SpatialPackageSource =
+    SpatialPackageSource::WorkerSdk(SpatialWorkerSdkPackage::CApiLinux);
+#[cfg(target_os = "macos")]
+static PACKAGE: SpatialPackageSource =
+    SpatialPackageSource::WorkerSdk(SpatialWorkerSdkPackage::CApiMac);
+#[cfg(target_os = "windows")]
+static PACKAGE: SpatialPackageSource =
+    SpatialPackageSource::WorkerSdk(SpatialWorkerSdkPackage::CApiWin);
+
+fn main() -> Result<(), Box<dyn Error>> {
     let lib_dir = match env::var("SPATIAL_LIB_DIR") {
         Ok(s) => s,
-        Err(_) => panic!("SPATIAL_LIB_DIR environment variable not set."),
+        Err(_) => download_libs()?,
     };
 
     let package_dir = Path::new(&lib_dir).join(PACKAGE_DIR);
 
     println!("cargo:rustc-link-search={}", package_dir.to_str().unwrap());
 
+    link_libs();
+
+    Ok(())
+}
+
+fn link_libs() {
     for lib in LIBS.iter() {
         println!("cargo:rustc-link-lib=static={}", lib)
     }
@@ -38,4 +58,20 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=gdi32");
         println!("cargo:rustc-link-lib=dylib=user32");
     }
+}
+
+fn download_libs() -> Result<String, Box<dyn Error>> {
+    let mut target_dir_path = PathBuf::from(env::var("OUT_DIR")?);
+    target_dir_path.push("spatial-libs");
+
+    let target_dir = target_dir_path.to_str().unwrap().to_owned();
+
+    if target_dir_path.exists() {
+        return Ok(target_dir);
+    }
+
+    let version = env::var("CARGO_PKG_VERSION")?;
+
+    download_package(PACKAGE, &version, &target_dir)?;
+    Ok(target_dir)
 }


### PR DESCRIPTION
This PR builds on the ideas in #167 

If `SPATIAL_LIB_DIR` is not set, the `spatialos-sdk-sys` package will download the packages for the target OS into its `OUT_DIR` location. 

In order to not bloat the `spatialos-sdk-sys` build dependencies, I've pulled out the package downloading code into its own little library. 

