### PR TITLE
Support pinned runtime version

### DIFF
--- a/cargo-spatial/src/config.rs
+++ b/cargo-spatial/src/config.rs
@@ -12,6 +12,11 @@ pub struct Config {
     /// Defaults to the latest supported version.
     pub spatial_sdk_version: String,
 
+    /// The runtime version to use for local launches.
+    ///
+    /// Defaults to the latest version pinned by this `cargo-spatial` version.
+    pub runtime_version: String,
+
     /// The list of worker projects to be built.
     ///
     /// If empty, the root project is assumed to contain all workers.
@@ -54,6 +59,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             spatial_sdk_version: "14.8.0".into(),
+            runtime_version: "14.5.4".into(),
             workers: vec![".".into()],
             codegen_out: "src/generated.rs".into(),
             schema_paths: vec![],

--- a/cargo-spatial/src/local.rs
+++ b/cargo-spatial/src/local.rs
@@ -42,7 +42,7 @@ pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Error<ErrorKi
         inner: Some(Box::new(e)),
     })?;
 
-    // Use `cargo install` to build workers and copy the exectuables to the build
+    // Use `cargo install` to build workers and copy the executables to the build
     // directory.
     //
     // TODO: Manually copy the built executables instead of using `cargo install`.
@@ -86,7 +86,13 @@ pub fn launch(config: &Config, launch: &LocalLaunch) -> Result<(), Error<ErrorKi
 
     // Run `spatial alpha local launch` with any user-specified flags.
     let mut command = process::Command::new("spatial");
-    command.args(&["alpha", "local", "launch"]);
+    command.args(&[
+        "alpha",
+        "local",
+        "launch",
+        "--runtime_version",
+        &config.runtime_version,
+    ]);
     if let Some(launch_config) = &launch.launch_config {
         command.arg(&format_arg("launch_config", launch_config));
     }


### PR DESCRIPTION
At some point in the past, supplying a runtime version to `spatial local launch` became mandatory. This then broke `cargo spatial local launch`. This PR resolves this issue. 