### PR TITLE
Derive `Default` for generated components and types

### DIFF
--- a/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
+++ b/spatialos-sdk-code-generator/src/generated_code_mod.tt.rs
@@ -50,7 +50,7 @@ impl Into<u32> for <#= enum_rust_name #> {
 impl_field_for_enum_field!(<#= enum_rust_name #>);
 <# } #>
 /* Types. */<# for type_name in &self.types { let type_def = self.get_type_definition(type_name); #>
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct <#= self.rust_name(&type_def.qualified_name) #> {<#
     for field in &type_def.fields {
     #>
@@ -76,7 +76,7 @@ impl ObjectField for <#= self.rust_name(&type_def.qualified_name) #> {
     let component_fields = self.get_component_fields(&component);
     let component_name = self.rust_name(&component.qualified_name);
     let update_name = format!("{}Update", component_name); #>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct <#= component_name #> {<#
     for field in &component_fields {
     #>

--- a/spatialos-sdk/src/worker/schema/float_ord.rs
+++ b/spatialos-sdk/src/worker/schema/float_ord.rs
@@ -26,6 +26,12 @@ macro_rules! float_ord_impl {
             }
         }
 
+        impl Default for FloatOrd<$f> {
+            fn default() -> Self {
+                0.0.into()
+            }
+        }
+
         impl PartialEq for FloatOrd<$f> {
             fn eq(&self, other: &Self) -> bool {
                 self.convert() == other.convert()


### PR DESCRIPTION
Allows you to write something like: 

```rust
improbable::Coordinates {
	x: 100.0.into(),
	..Default::default(),
}
```

or similar with any generated components/types (it seems update already had this implemented).